### PR TITLE
Fix warnings from Qt and compiler

### DIFF
--- a/src/VAC/Layer.h
+++ b/src/VAC/Layer.h
@@ -42,7 +42,7 @@ private:
                bool isVisible);
 
 public:
-    Layer(const QString & layerName = "Layer");
+    explicit Layer(const QString & layerName = QStringLiteral("Layer"));
     ~Layer() override;
 
     Layer * clone() override;
@@ -73,9 +73,11 @@ public:
     void setVisible(bool b);
 
 signals:
-    void changed();
-    void checkpoint();
-    void needUpdatePicking();
+    // defined in base class (Scene Object)
+    // void changed();
+    // void checkpoint();
+    // void needUpdatePicking();
+
     void selectionChanged();
     void layerAttributesChanged();
 

--- a/src/VAC/LayersWidget.cpp
+++ b/src/VAC/LayersWidget.cpp
@@ -381,9 +381,9 @@ void LayersWidget::onSceneLayerAttributesChanged_()
 void LayersWidget::updateUiFromScene_()
 {
     // Show as many existing LayerWidgets as necessary
-    int numLayers = scene()->numLayers();
-    int numLayerWidgets = layerWidgets_.size();
-    int newNumVisibleLayerWidgets = std::min(numLayers, numLayerWidgets);
+    const auto numLayers = scene()->numLayers();
+    const auto numLayerWidgets = int(layerWidgets_.size());
+    const auto newNumVisibleLayerWidgets = std::min(numLayers, numLayerWidgets);
     for (int i = numVisibleLayerWidgets_; i < newNumVisibleLayerWidgets; ++i) {
         layerWidgets_[i]->show();
         ++numVisibleLayerWidgets_;
@@ -425,7 +425,7 @@ void LayersWidget::updateUiFromScene_()
 // Precondition: all LayerWidgets are visible
 void LayersWidget::createNewLayerWidget_()
 {
-    impl_::LayerWidget * layerWidget = new impl_::LayerWidget(layerWidgets_.size());
+    impl_::LayerWidget * layerWidget = new impl_::LayerWidget(int(layerWidgets_.size()));
     ++numVisibleLayerWidgets_;
     layerWidgets_.push_back(layerWidget);
     layerListLayout_->addWidget(layerWidget);


### PR DESCRIPTION
* Signals don't need to be redeclared, and QMetaObject::indexOfMethod complains
* int<->size_t is always an issue on 64-bit