### PR TITLE
Replace qt foreach keyword for range-based loops

### DIFF
--- a/src/VAC/AnimatedCycleWidget.cpp
+++ b/src/VAC/AnimatedCycleWidget.cpp
@@ -525,7 +525,7 @@ void AnimatedCycleWidget::addSelectedCells()
     {
         CellSet selectedCells = vac->selectedCells();
 
-        foreach(Cell * cell, selectedCells)
+        for(Cell * cell: selectedCells)
             createNodeAndItem(cell);
 
         computeItemHeightAndY();
@@ -831,7 +831,7 @@ void AnimatedCycleWidget::deleteItem(GraphicsNodeItem * item)
     }
 
     // Delete arrows starting or ending at item
-    foreach(GraphicsArrowItem * arrowItem, arrowItems)
+    for(GraphicsArrowItem * arrowItem: arrowItems)
         deleteArrow(arrowItem);
 
     // Delete node and item
@@ -882,7 +882,7 @@ void AnimatedCycleWidget::computeSceneFromAnimatedCycle()
     }
 
     // Create items
-    foreach(AnimatedCycleNode * node, animatedCycle_.nodes())
+    for(AnimatedCycleNode * node: animatedCycle_.nodes())
     {
         GraphicsNodeItem * item = new GraphicsNodeItem(node, this);
         scene_->addItem(item);
@@ -893,7 +893,7 @@ void AnimatedCycleWidget::computeSceneFromAnimatedCycle()
     computeItemHeightAndY();
 
     // Create arrows
-    foreach(AnimatedCycleNode * node, animatedCycle_.nodes())
+    for(AnimatedCycleNode * node: animatedCycle_.nodes())
     {
         GraphicsNodeItem * item = nodeToItem_[node];
 
@@ -1045,7 +1045,7 @@ void AnimatedCycleWidget::animate()
 
     // Get all items
     QSet<GraphicsNodeItem*> items;
-    foreach(QGraphicsItem * i, scene_->items())
+    for(QGraphicsItem * i: scene_->items())
     {
         GraphicsNodeItem * item = qgraphicsitem_cast<GraphicsNodeItem *>(i);
         if(item)
@@ -1053,7 +1053,7 @@ void AnimatedCycleWidget::animate()
     }
 
     // Initialize values
-    foreach(GraphicsNodeItem * item, items)
+    for(GraphicsNodeItem * item: items)
     {
         deltaX[item] = 0;
         deltaXNum[item] = 0;
@@ -1115,7 +1115,7 @@ void AnimatedCycleWidget::animate()
 
 
     // Increase width of inbetween edges
-    foreach(GraphicsNodeItem * item, items)
+    for(GraphicsNodeItem * item: items)
     {
         InbetweenEdge * inbetweenEdge = item->node()->cell()->toInbetweenEdge();
         if(inbetweenEdge)
@@ -1222,7 +1222,7 @@ void AnimatedCycleWidget::animate()
     }
 
     // Compute average of delta
-    foreach(GraphicsNodeItem * item, items)
+    for(GraphicsNodeItem * item: items)
     {
         if(deltaMinX[item] > deltaMaxX[item])
         {

--- a/src/VAC/AnimatedCycleWidget.cpp
+++ b/src/VAC/AnimatedCycleWidget.cpp
@@ -831,7 +831,7 @@ void AnimatedCycleWidget::deleteItem(GraphicsNodeItem * item)
     }
 
     // Delete arrows starting or ending at item
-    for(GraphicsArrowItem * arrowItem: arrowItems)
+    for(GraphicsArrowItem * arrowItem: qAsConst(arrowItems))
         deleteArrow(arrowItem);
 
     // Delete node and item
@@ -882,18 +882,22 @@ void AnimatedCycleWidget::computeSceneFromAnimatedCycle()
     }
 
     // Create items
-    for(AnimatedCycleNode * node: animatedCycle_.nodes())
+    std::for_each(std::begin(animatedCycle_.nodes())
+                  , std::end(animatedCycle_.nodes())
+                  , [&](AnimatedCycleNode * node)
     {
         GraphicsNodeItem * item = new GraphicsNodeItem(node, this);
         scene_->addItem(item);
         nodeToItem_[node] = item;
-    }
+    });
 
     // Set item height and Y
     computeItemHeightAndY();
 
     // Create arrows
-    for(AnimatedCycleNode * node: animatedCycle_.nodes())
+    std::for_each(std::begin(animatedCycle_.nodes())
+                  , std::end(animatedCycle_.nodes())
+                  , [&](AnimatedCycleNode * node)
     {
         GraphicsNodeItem * item = nodeToItem_[node];
 
@@ -930,7 +934,7 @@ void AnimatedCycleWidget::computeSceneFromAnimatedCycle()
             scene_->addItem(arrow);
             itemToBeforeArrow_[item] = arrow;
         }
-    }
+    });
 }
 
 void AnimatedCycleWidget::computeItemHeightAndY()
@@ -1045,15 +1049,17 @@ void AnimatedCycleWidget::animate()
 
     // Get all items
     QSet<GraphicsNodeItem*> items;
-    for(QGraphicsItem * i: scene_->items())
+    std::for_each(std::begin(scene_->items())
+                  , std::end(scene_->items())
+                  , [&](QGraphicsItem * i)
     {
         GraphicsNodeItem * item = qgraphicsitem_cast<GraphicsNodeItem *>(i);
         if(item)
             items << item;
-    }
+    });
 
     // Initialize values
-    for(GraphicsNodeItem * item: items)
+    for(GraphicsNodeItem * item: qAsConst(items))
     {
         deltaX[item] = 0;
         deltaXNum[item] = 0;
@@ -1115,7 +1121,7 @@ void AnimatedCycleWidget::animate()
 
 
     // Increase width of inbetween edges
-    for(GraphicsNodeItem * item: items)
+    for(GraphicsNodeItem * item: qAsConst(items))
     {
         InbetweenEdge * inbetweenEdge = item->node()->cell()->toInbetweenEdge();
         if(inbetweenEdge)
@@ -1222,7 +1228,7 @@ void AnimatedCycleWidget::animate()
     }
 
     // Compute average of delta
-    for(GraphicsNodeItem * item: items)
+    for(GraphicsNodeItem * item: qAsConst(items))
     {
         if(deltaMinX[item] > deltaMaxX[item])
         {

--- a/src/VAC/Background/Background.cpp
+++ b/src/VAC/Background/Background.cpp
@@ -193,7 +193,7 @@ void Background::computeCache_() const
         //   intWildcards[i]     = 15
         QStringList stringWildcards;
         QList<int> intWildcards;
-        foreach(QFileInfo i, files)
+        for(QFileInfo i: files)
         {
             // Get wildcard as string
             QString fileName = i.fileName();

--- a/src/VAC/Background/BackgroundRenderer.cpp
+++ b/src/VAC/Background/BackgroundRenderer.cpp
@@ -35,7 +35,7 @@ BackgroundRenderer::BackgroundRenderer(
 void BackgroundRenderer::cleanup()
 {
     // Delete all textures allocated in GPU
-    for (QOpenGLTexture * texture: textures_)
+    for (QOpenGLTexture * texture: qAsConst(textures_))
     {
         // Note 1: Qt documentation doesn't specify whether QOpenGLTexture's
         // destructor destroys the underlying OpenGL texture object, so we

--- a/src/VAC/Background/BackgroundRenderer.cpp
+++ b/src/VAC/Background/BackgroundRenderer.cpp
@@ -35,7 +35,7 @@ BackgroundRenderer::BackgroundRenderer(
 void BackgroundRenderer::cleanup()
 {
     // Delete all textures allocated in GPU
-    foreach (QOpenGLTexture * texture, textures_)
+    for (QOpenGLTexture * texture: textures_)
     {
         // Note 1: Qt documentation doesn't specify whether QOpenGLTexture's
         // destructor destroys the underlying OpenGL texture object, so we

--- a/src/VAC/Background/BackgroundWidget.cpp
+++ b/src/VAC/Background/BackgroundWidget.cpp
@@ -224,7 +224,7 @@ void BackgroundWidget::setBackground(Background * background)
     // Disable all widgets if background_ == NULL
     bool areChildrenEnabled = background_ ? true : false;
     QList<QWidget*> children = findChildren<QWidget*>(QString(), Qt::FindDirectChildrenOnly);
-    foreach (QWidget * w, children)
+    for (QWidget * w: children)
         w->setEnabled(areChildrenEnabled);
 
     // Set widgets values from background values

--- a/src/VAC/GLWidget.cpp
+++ b/src/VAC/GLWidget.cpp
@@ -737,7 +737,7 @@ void GLWidget::initializeGL()
     if (queryExtensions) {
         QList<QByteArray> extensions = context()->extensions().toList();
         qDebug() << "Supported extensions (" << extensions.count() << ")";
-        foreach (const QByteArray &extension, extensions)
+        for (const QByteArray &extension: extensions)
             qDebug() << "    " << extension;
     }
 

--- a/src/VAC/MainWindow.cpp
+++ b/src/VAC/MainWindow.cpp
@@ -383,7 +383,7 @@ void MainWindow::addToUndoStack()
 
 void MainWindow::clearUndoStack_()
 {
-    for(UndoItem p: undoStack_)
+    for(UndoItem p: qAsConst(undoStack_))
         delete p.second;
 
     undoStack_.clear();

--- a/src/VAC/MainWindow.cpp
+++ b/src/VAC/MainWindow.cpp
@@ -383,7 +383,7 @@ void MainWindow::addToUndoStack()
 
 void MainWindow::clearUndoStack_()
 {
-    foreach(UndoItem p, undoStack_)
+    for(UndoItem p: undoStack_)
         delete p.second;
 
     undoStack_.clear();

--- a/src/VAC/MultiView.cpp
+++ b/src/VAC/MultiView.cpp
@@ -382,7 +382,7 @@ MultiView::~MultiView()
 
 void MultiView::update()
 {
-    for(ViewWidget * viewWidget: views_)
+    for(ViewWidget * viewWidget: qAsConst(views_))
     {
         View * view = viewFromViewWidget_(viewWidget);
         if(view->isVisible())
@@ -392,7 +392,7 @@ void MultiView::update()
 
 void MultiView::updatePicking()
 {
-    for(ViewWidget * viewWidget: views_)
+    for(ViewWidget * viewWidget: qAsConst(views_))
     {
         View * view = viewFromViewWidget_(viewWidget);
         if(view->isVisible())

--- a/src/VAC/MultiView.cpp
+++ b/src/VAC/MultiView.cpp
@@ -382,7 +382,7 @@ MultiView::~MultiView()
 
 void MultiView::update()
 {
-    foreach(ViewWidget * viewWidget, views_)
+    for(ViewWidget * viewWidget: views_)
     {
         View * view = viewFromViewWidget_(viewWidget);
         if(view->isVisible())
@@ -392,7 +392,7 @@ void MultiView::update()
 
 void MultiView::updatePicking()
 {
-    foreach(ViewWidget * viewWidget, views_)
+    for(ViewWidget * viewWidget: views_)
     {
         View * view = viewFromViewWidget_(viewWidget);
         if(view->isVisible())

--- a/src/VAC/ObjectPropertiesWidget.cpp
+++ b/src/VAC/ObjectPropertiesWidget.cpp
@@ -358,7 +358,7 @@ QString ObjectPropertiesWidget::getStringType(const VectorAnimationComplex::Cell
     int nsoe = 0;
     int nsce = 0;
     int nsf = 0;
-    foreach(VectorAnimationComplex::Cell * cell, cells)
+    for(VectorAnimationComplex::Cell * cell: cells)
     {
         if(cell->toKeyVertex())
             ++nkv;
@@ -445,7 +445,7 @@ void ObjectPropertiesWidget::setId(const VectorAnimationComplex::CellSet & cells
 
     int i = 0; // count cells
     int j = 0; // num on line
-    foreach(VectorAnimationComplex::Cell * cell, cells)
+    for(VectorAnimationComplex::Cell * cell: cells)
     {
         j = i % numIdPerLine;
         if(i==0)

--- a/src/VAC/OpenGL.h
+++ b/src/VAC/OpenGL.h
@@ -31,7 +31,7 @@
 //   QList extensions = context()->extensions().toList();
 //   std::sort(extensions);
 //   qDebug() << "Supported extensions (" << extensions.count() << ")";
-//   foreach (const QByteArray &extension, extensions)
+//   for (const QByteArray &extension: extensions)
 //       qDebug() << "    " << extension;
 //
 //   // Check if extension is supported

--- a/src/VAC/Scene.cpp
+++ b/src/VAC/Scene.cpp
@@ -120,7 +120,7 @@ void Scene::copyFrom(Scene * other)
     clear(true);
 
     // Copy layers
-    foreach(Layer * layer, other->layers_)
+    for(Layer * layer: other->layers_)
         addLayer_(layer->clone(), true);
     activeLayerIndex_ = other->activeLayerIndex_;
 
@@ -143,7 +143,7 @@ void Scene::clear(bool silent)
     blockSignals(true);
 
     // Delete all layers
-    foreach(Layer * layer, layers_)
+    for(Layer * layer: layers_)
         delete layer;
     layers_.clear();
     activeLayerIndex_ = -1;
@@ -177,7 +177,7 @@ void Scene::save(QTextStream & out)
     out << Save::newField("SceneObjects");
     out << "\n" << Save::indent() << "[";
     Save::incrIndent();
-    foreach(Layer * layer, layers_)
+    for(Layer * layer: layers_)
     {
         out << Save::openCurlyBrackets();
         layer->vac()->save(out);
@@ -191,7 +191,7 @@ void Scene::save(QTextStream & out)
 void Scene::exportSVG(Time t, QTextStream & out)
 {
     // Export Layers
-    foreach(Layer * layer, layers_)
+    for(Layer * layer: layers_)
     {
         layer->background()->exportSVG(
             t.frame(), out, left(), top(), width(), height());
@@ -231,7 +231,7 @@ void Scene::read(QTextStream & in)
 
 void Scene::writeAllLayers(XmlStreamWriter & xml)
 {
-    foreach(Layer * layer, layers_)
+    for(Layer * layer: layers_)
     {
         xml.writeStartElement("layer");
         layer->write(xml);
@@ -289,7 +289,7 @@ void Scene::writeCanvas(XmlStreamWriter & xml)
 
 void Scene::relativeRemap(const QDir & oldDir, const QDir & newDir)
 {
-    foreach(Layer * layer, layers_)
+    for(Layer * layer: layers_)
     {
         layer->background()->relativeRemap(oldDir, newDir);
     }
@@ -346,7 +346,7 @@ void Scene::drawCanvas(ViewSettings & /*viewSettings*/)
 void Scene::draw(Time time, ViewSettings & viewSettings)
 {
     // Draw layers
-    foreach(Layer * layer, layers_)
+    for(Layer * layer: layers_)
     {
         layer->draw(time, viewSettings);
     }
@@ -414,19 +414,19 @@ void Scene::toggle(Time time, int index, int id)
 
 void Scene::deselectAll(Time time)
 {
-    foreach(Layer * layer, layers_)
+    for(Layer * layer: layers_)
         layer->deselectAll(time);
 }
 
 void Scene::deselectAll()
 {
-    foreach(Layer * layer, layers_)
+    for(Layer * layer: layers_)
         layer->deselectAll();
 }
 
 void Scene::invertSelection()
 {
-    foreach(Layer * layer, layers_)
+    for(Layer * layer: layers_)
         layer->invertSelection();
 }
 

--- a/src/VAC/Scene.cpp
+++ b/src/VAC/Scene.cpp
@@ -120,7 +120,7 @@ void Scene::copyFrom(Scene * other)
     clear(true);
 
     // Copy layers
-    for(Layer * layer: other->layers_)
+    for(Layer * layer: qAsConst(other->layers_))
         addLayer_(layer->clone(), true);
     activeLayerIndex_ = other->activeLayerIndex_;
 
@@ -143,7 +143,7 @@ void Scene::clear(bool silent)
     blockSignals(true);
 
     // Delete all layers
-    for(Layer * layer: layers_)
+    for(Layer * layer: qAsConst(layers_))
         delete layer;
     layers_.clear();
     activeLayerIndex_ = -1;
@@ -191,7 +191,7 @@ void Scene::save(QTextStream & out)
 void Scene::exportSVG(Time t, QTextStream & out)
 {
     // Export Layers
-    for(Layer * layer: layers_)
+    for(Layer * layer: qAsConst(layers_))
     {
         layer->background()->exportSVG(
             t.frame(), out, left(), top(), width(), height());
@@ -231,7 +231,7 @@ void Scene::read(QTextStream & in)
 
 void Scene::writeAllLayers(XmlStreamWriter & xml)
 {
-    for(Layer * layer: layers_)
+    for(Layer * layer: qAsConst(layers_))
     {
         xml.writeStartElement("layer");
         layer->write(xml);
@@ -289,7 +289,7 @@ void Scene::writeCanvas(XmlStreamWriter & xml)
 
 void Scene::relativeRemap(const QDir & oldDir, const QDir & newDir)
 {
-    for(Layer * layer: layers_)
+    for(Layer * layer: qAsConst(layers_))
     {
         layer->background()->relativeRemap(oldDir, newDir);
     }
@@ -346,7 +346,7 @@ void Scene::drawCanvas(ViewSettings & /*viewSettings*/)
 void Scene::draw(Time time, ViewSettings & viewSettings)
 {
     // Draw layers
-    for(Layer * layer: layers_)
+    for(Layer * layer: qAsConst(layers_))
     {
         layer->draw(time, viewSettings);
     }
@@ -414,19 +414,19 @@ void Scene::toggle(Time time, int index, int id)
 
 void Scene::deselectAll(Time time)
 {
-    for(Layer * layer: layers_)
+    for(Layer * layer: qAsConst(layers_))
         layer->deselectAll(time);
 }
 
 void Scene::deselectAll()
 {
-    for(Layer * layer: layers_)
+    for(Layer * layer: qAsConst(layers_))
         layer->deselectAll();
 }
 
 void Scene::invertSelection()
 {
-    for(Layer * layer: layers_)
+    for(Layer * layer: qAsConst(layers_))
         layer->invertSelection();
 }
 

--- a/src/VAC/SelectionInfoWidget.cpp
+++ b/src/VAC/SelectionInfoWidget.cpp
@@ -44,7 +44,7 @@ void SelectionInfoWidget::updateInfo()
     VAC * vac = global()->mainWindow()->scene()->activeVAC();
     if(vac)
     {
-        foreach(Cell * c, vac->selectedCells())
+        for(Cell * c: vac->selectedCells())
         {
             text += QString::number(c->id());
             text += " ";

--- a/src/VAC/SvgImportDialog.cpp
+++ b/src/VAC/SvgImportDialog.cpp
@@ -79,7 +79,8 @@ SvgImportDialog::SvgImportDialog(QWidget * parent) :
     layout->addWidget(warning);
     layout->addSpacing(15);
     layout->addWidget(vertexModeLabel);
-    for (auto* button : vertexModeButtons->buttons()) {
+    const auto& buttons = vertexModeButtons->buttons();
+    for (auto* button : buttons) {
         layout->addWidget(button);
     }
     layout->addSpacing(15);

--- a/src/VAC/Timeline.cpp
+++ b/src/VAC/Timeline.cpp
@@ -110,7 +110,7 @@ void Timeline_HBar::paintEvent (QPaintEvent * /*event*/)
     // current frames
     painter.setBrush(Qt::red);
     painter.setPen(Qt::NoPen);
-    foreach(View * view, w_->views_)
+    for(View * view: w_->views_)
     {
         painter.drawRect(10*(view->activeTime().floatTime()) - w_->totalPixelOffset_ + 1, 1, 9, height()-2);
     }
@@ -157,7 +157,7 @@ void Timeline_HBar::paintEvent (QPaintEvent * /*event*/)
     // Draw inbetween cells
     painter.setPen(QColor(0,0,0));
     painter.setBrush(QColor(0,0,0));
-    foreach(InbetweenCell * inbetweenCell, inbetweenCells)
+    for(InbetweenCell * inbetweenCell: inbetweenCells)
     {
         double t1 = inbetweenCell->beforeTime().floatTime();
         double t2 = inbetweenCell->afterTime().floatTime();
@@ -167,7 +167,7 @@ void Timeline_HBar::paintEvent (QPaintEvent * /*event*/)
         //                 10*t2 - w_->totalPixelOffset_ + 5, 5);
     }
     painter.setBrush(QColor(255,0,0));
-    foreach(InbetweenCell * inbetweenCell, selectedInbetweenCells)
+    for(InbetweenCell * inbetweenCell: selectedInbetweenCells)
     {
         double t1 = inbetweenCell->beforeTime().floatTime();
         double t2 = inbetweenCell->afterTime().floatTime();
@@ -180,13 +180,13 @@ void Timeline_HBar::paintEvent (QPaintEvent * /*event*/)
     // Draw key cells
     painter.setPen(QColor(0,0,0));
     painter.setBrush(QColor(0,0,0));
-    foreach(KeyCell * keyCell, keyCells)
+    for(KeyCell * keyCell: keyCells)
     {
         double t = keyCell->time().floatTime();
         painter.drawEllipse(10*t - w_->totalPixelOffset_ + 2, 2, 6, 6);
     }
     painter.setBrush(QColor(255,0,0));
-    foreach(KeyCell * keyCell, selectedKeyCells)
+    for(KeyCell * keyCell: selectedKeyCells)
     {
         double t = keyCell->time().floatTime();
         painter.drawEllipse(10*t - w_->totalPixelOffset_ + 2, 2, 6, 6);
@@ -753,7 +753,7 @@ void Timeline::play()
     if(view)
     {
         playedViews_ << global()->activeView();
-        foreach(View * view, playedViews())
+        for(View * view: playedViews())
             view->disablePicking();
         elapsedTimer_.start();
         timer_->start();
@@ -764,7 +764,7 @@ void Timeline::play()
 void Timeline::pause()
 {
     timer_->stop();
-    foreach(View * view, playedViews())
+    for(View * view: playedViews())
         view->enablePicking();
     roundPlayedViews();
     playPauseButton_->setIcon(QIcon(":/images/go-play.png"));
@@ -781,7 +781,7 @@ void Timeline::playPause()
 
 void Timeline::roundPlayedViews()
 {
-    foreach(View * view, playedViews())
+    for(View * view: playedViews())
     {
         Time t = view->activeTime();
         double floatFrame = t.floatTime();
@@ -879,7 +879,7 @@ void Timeline::timerTimeout()
 
     elapsedTimer_.restart();
 
-    foreach(View * view, playedViews())
+    for(View * view: playedViews())
     {
         if(isPlaying() && subframeInbetweening())
         {

--- a/src/VAC/Timeline.cpp
+++ b/src/VAC/Timeline.cpp
@@ -110,7 +110,7 @@ void Timeline_HBar::paintEvent (QPaintEvent * /*event*/)
     // current frames
     painter.setBrush(Qt::red);
     painter.setPen(Qt::NoPen);
-    for(View * view: w_->views_)
+    for(View * view: qAsConst(w_->views_))
     {
         painter.drawRect(10*(view->activeTime().floatTime()) - w_->totalPixelOffset_ + 1, 1, 9, height()-2);
     }
@@ -753,7 +753,7 @@ void Timeline::play()
     if(view)
     {
         playedViews_ << global()->activeView();
-        for(View * view: playedViews())
+        for(View * view: qAsConst(playedViews_))
             view->disablePicking();
         elapsedTimer_.start();
         timer_->start();
@@ -764,7 +764,7 @@ void Timeline::play()
 void Timeline::pause()
 {
     timer_->stop();
-    for(View * view: playedViews())
+    for(View * view: qAsConst(playedViews_))
         view->enablePicking();
     roundPlayedViews();
     playPauseButton_->setIcon(QIcon(":/images/go-play.png"));
@@ -781,7 +781,7 @@ void Timeline::playPause()
 
 void Timeline::roundPlayedViews()
 {
-    for(View * view: playedViews())
+    for(View * view: qAsConst(playedViews_))
     {
         Time t = view->activeTime();
         double floatFrame = t.floatTime();
@@ -879,7 +879,7 @@ void Timeline::timerTimeout()
 
     elapsedTimer_.restart();
 
-    for(View * view: playedViews())
+    for(View * view: qAsConst(playedViews_))
     {
         if(isPlaying() && subframeInbetweening())
         {

--- a/src/VAC/VectorAnimationComplex/Algorithms.cpp
+++ b/src/VAC/VectorAnimationComplex/Algorithms.cpp
@@ -36,10 +36,10 @@ CellSet connected(const CellSet & cells)
     while(addedCells.size() != 0)
     {
         CellSet newAddedCells;
-        foreach(Cell * c, addedCells)
+        for(Cell * c: addedCells)
         {
             CellSet neighbourhood = c->neighbourhood();
-            foreach(Cell * d, neighbourhood)
+            for(Cell * d: neighbourhood)
             {
                 if(!res.contains(d))
                 {
@@ -59,7 +59,7 @@ CellSet closure(Cell * c)
 {
     CellSet res;
     res << c;
-    foreach(Cell * b, c->boundary())
+    for(Cell * b: c->boundary())
         res << b;
     return res;
 }
@@ -67,10 +67,10 @@ CellSet closure(Cell * c)
 CellSet closure(const CellSet & cells)
 {
     CellSet res;
-    foreach(Cell * c, cells)
+    for(Cell * c: cells)
     {
         res << c;
-        foreach(Cell * b, c->boundary())
+        for(Cell * b: c->boundary())
             res << b;
     }
     return res;
@@ -80,7 +80,7 @@ CellSet fullstar(Cell * c)
 {
     CellSet res;
     res << c;
-    foreach(Cell * b, c->star())
+    for(Cell * b: c->star())
         res << b;
     return res;
 }
@@ -88,10 +88,10 @@ CellSet fullstar(Cell * c)
 CellSet fullstar(const CellSet & cells)
 {
     CellSet res;
-    foreach(Cell * c, cells)
+    for(Cell * c: cells)
     {
         res << c;
-        foreach(Cell * b, c->star())
+        for(Cell * b: c->star())
             res << b;
     }
     return res;
@@ -105,11 +105,11 @@ QList<KeyEdgeSet> connectedComponents(const KeyEdgeSet & cells)
     // Initialize data structure for algorithm
 
     QMap<KeyEdge *, bool> isMarked;
-    foreach(KeyEdge * edge, cells)
+    for(KeyEdge * edge: cells)
         isMarked[edge] = false;
 
     QMap<KeyEdge *, int> component;
-    foreach(KeyEdge * edge, cells)
+    for(KeyEdge * edge: cells)
         component[edge] = -1;
 
     int numComponents = 0;
@@ -117,7 +117,7 @@ QList<KeyEdgeSet> connectedComponents(const KeyEdgeSet & cells)
 
     // Execute algorithm
 
-    foreach(KeyEdge * edge, cells)
+    for(KeyEdge * edge: cells)
     {
         // if has already been assigned a connected component, do nothing
         if(!isMarked[edge])
@@ -148,7 +148,7 @@ QList<KeyEdgeSet> connectedComponents(const KeyEdgeSet & cells)
                 component[edgeToVisit] = numComponents-1;
 
                 //  Find other edges to visit
-                foreach(KeyEdge * other, cells)
+                for(KeyEdge * other: cells)
                 {
                     if(!isMarked[other]) // note: this exlude other == edgeToVisit
                     {
@@ -171,7 +171,7 @@ QList<KeyEdgeSet> connectedComponents(const KeyEdgeSet & cells)
     for(int i=0; i<numComponents; ++i)
         res << KeyEdgeSet();
 
-    foreach(KeyEdge * edge, cells)
+    for(KeyEdge * edge: cells)
         res[component[edge]] << edge;
 
     return res;

--- a/src/VAC/VectorAnimationComplex/Algorithms.cpp
+++ b/src/VAC/VectorAnimationComplex/Algorithms.cpp
@@ -59,7 +59,8 @@ CellSet closure(Cell * c)
 {
     CellSet res;
     res << c;
-    for(Cell * b: c->boundary())
+    const auto& boundary = c->boundary();
+    for(Cell * b: boundary)
         res << b;
     return res;
 }
@@ -70,7 +71,8 @@ CellSet closure(const CellSet & cells)
     for(Cell * c: cells)
     {
         res << c;
-        for(Cell * b: c->boundary())
+        const auto& boundary = c->boundary();
+        for(Cell * b: boundary)
             res << b;
     }
     return res;
@@ -80,7 +82,8 @@ CellSet fullstar(Cell * c)
 {
     CellSet res;
     res << c;
-    for(Cell * b: c->star())
+    const auto& star = c->star();
+    for(Cell * b: star)
         res << b;
     return res;
 }
@@ -88,10 +91,11 @@ CellSet fullstar(Cell * c)
 CellSet fullstar(const CellSet & cells)
 {
     CellSet res;
-    for(Cell * c: cells)
+    for(Cell * c: qAsConst(cells))
     {
         res << c;
-        for(Cell * b: c->star())
+        const auto& star = c->star();
+        for(Cell * b: star)
             res << b;
     }
     return res;

--- a/src/VAC/VectorAnimationComplex/AnimatedCycle.cpp
+++ b/src/VAC/VectorAnimationComplex/AnimatedCycle.cpp
@@ -251,7 +251,7 @@ AnimatedCycle::~AnimatedCycle()
 
 void AnimatedCycle::clear()
 {
-    foreach(AnimatedCycleNode * node, nodes())
+    for(AnimatedCycleNode * node: nodes())
         delete node;
 
     first_ = 0;
@@ -263,10 +263,10 @@ void AnimatedCycle::copyFrom(const AnimatedCycle & other)
 
     QMap<AnimatedCycleNode *, AnimatedCycleNode *> oldToNew;
     oldToNew[0] = 0;
-    foreach(AnimatedCycleNode * oldNode, other.nodes())
+    for(AnimatedCycleNode * oldNode: other.nodes())
         oldToNew[oldNode] = new AnimatedCycleNode(oldNode->cell());
 
-    foreach(AnimatedCycleNode * oldNode, other.nodes())
+    for(AnimatedCycleNode * oldNode: other.nodes())
     {
         AnimatedCycleNode * newNode = oldToNew[oldNode];
         newNode->setPrevious(oldToNew[oldNode->previous()]);
@@ -345,14 +345,14 @@ QSet<AnimatedCycleNode*> AnimatedCycle::nodes() const
 CellSet AnimatedCycle::cells() const
 {
     CellSet res;
-    foreach(AnimatedCycleNode * node, nodes())
+    for(AnimatedCycleNode * node: nodes())
         res << node->cell();
     return res;
 }
 KeyCellSet AnimatedCycle::beforeCells() const
 {
     KeyCellSet res;
-    foreach(AnimatedCycleNode * node, nodes())
+    for(AnimatedCycleNode * node: nodes())
     {
         if(!node->before())
             res.unite(node->cell()->beforeCells());
@@ -362,7 +362,7 @@ KeyCellSet AnimatedCycle::beforeCells() const
 KeyCellSet AnimatedCycle::afterCells() const
 {
     KeyCellSet res;
-    foreach(AnimatedCycleNode * node, nodes())
+    for(AnimatedCycleNode * node: nodes())
     {
         if(!node->after())
             res.unite(node->cell()->afterCells());
@@ -374,7 +374,7 @@ KeyCellSet AnimatedCycle::afterCells() const
 // Replace pointed vertex
 void AnimatedCycle::replaceVertex(KeyVertex * oldVertex, KeyVertex * newVertex)
 {
-    foreach(AnimatedCycleNode * node, nodes())
+    for(AnimatedCycleNode * node: nodes())
     {
         if(node->cell()->toKeyVertex() == oldVertex)
             node->setCell(newVertex);
@@ -382,7 +382,7 @@ void AnimatedCycle::replaceVertex(KeyVertex * oldVertex, KeyVertex * newVertex)
 }
 void AnimatedCycle::replaceHalfedge(const KeyHalfedge & oldHalfedge, const KeyHalfedge & newHalfedge)
 {
-    foreach(AnimatedCycleNode * node, nodes())
+    for(AnimatedCycleNode * node: nodes())
     {
         if(node->cell()->toKeyEdge() == oldHalfedge.edge)
         {
@@ -495,7 +495,7 @@ void AnimatedCycle::replaceEdges(KeyEdge * oldEdge, const KeyEdgeList & newEdges
     }
     else
     {
-        foreach(AnimatedCycleNode * oldEdgeNode, getNodes(oldEdge))
+        for(AnimatedCycleNode * oldEdgeNode: getNodes(oldEdge))
         {
             int n = newEdges.size();
             bool side = oldEdgeNode->side();
@@ -581,7 +581,7 @@ void AnimatedCycle::replaceEdges(KeyEdge * oldEdge, const KeyEdgeList & newEdges
 QSet<AnimatedCycleNode*>  AnimatedCycle::getNodes(Cell * cell)
 {
     QSet<AnimatedCycleNode*> res;
-    foreach(AnimatedCycleNode * node, nodes())
+    for(AnimatedCycleNode * node: nodes())
     {
         if(node->cell() == cell)
             res << node;
@@ -592,7 +592,7 @@ QSet<AnimatedCycleNode*>  AnimatedCycle::getNodes(Cell * cell)
 void AnimatedCycle::replaceInbetweenVertex(InbetweenVertex * sv,
                             InbetweenVertex * sv1, KeyVertex * kv, InbetweenVertex * sv2)
 {
-    foreach(AnimatedCycleNode * nsv, getNodes(sv))
+    for(AnimatedCycleNode * nsv: getNodes(sv))
     {
         // Create three new nodes
         AnimatedCycleNode * nsv1 = new AnimatedCycleNode(sv1);
@@ -775,7 +775,7 @@ void AnimatedCycle::replaceInbetweenEdge(InbetweenEdge * se,
     else
     {
         // Perform substitution
-        foreach(AnimatedCycleNode * nse, getNodes(se))
+        for(AnimatedCycleNode * nse: getNodes(se))
         {
             // Get boundary nodes
             AnimatedCycleNode * nkvprevious = nse->previous(t);
@@ -1072,7 +1072,7 @@ void AnimatedCycle::sample(Time time, QList<Eigen::Vector2d> & out)
 
 void AnimatedCycle::remapPointers(VAC * newVAC)
 {
-    foreach(AnimatedCycleNode * node, nodes())
+    for(AnimatedCycleNode * node: nodes())
     {
         node->setCell(newVAC->getCell(node->cell()->id()));
     }
@@ -1147,14 +1147,14 @@ QString AnimatedCycle::toString() const
     // Create correspondence between node pointers and [1..n] where n is the number of nodes
     QMap<AnimatedCycleNode*,int> nodeMap;
     int id = 1;
-    foreach(AnimatedCycleNode * node, nodes())
+    for(AnimatedCycleNode * node: nodes())
         nodeMap[node] = id++;
 
     // Write
     QString res;
     res += "[";
     bool first = true;
-    foreach(AnimatedCycleNode * node, nodes())
+    for(AnimatedCycleNode * node: nodes())
     {
         if(first)
             first = false;
@@ -1244,12 +1244,12 @@ QTextStream & operator<<(QTextStream & out, const VectorAnimationComplex::Animat
     // Create correspondence between node pointers and [0..n-1] where n is the number of nodes
     QMap<AnimatedCycleNode*,int> nodeMap;
     int id = 0;
-    foreach(AnimatedCycleNode * node, cycle.nodes())
+    for(AnimatedCycleNode * node: cycle.nodes())
         nodeMap[node] = id++;
 
     // Write to file
     out << "[";
-    foreach(AnimatedCycleNode * node, cycle.nodes())
+    for(AnimatedCycleNode * node: cycle.nodes())
     {
         if(nodeMap[node]!=0) out << " ,";
         out << " "

--- a/src/VAC/VectorAnimationComplex/AnimatedVertex.cpp
+++ b/src/VAC/VectorAnimationComplex/AnimatedVertex.cpp
@@ -117,7 +117,7 @@ Eigen::Vector2d AnimatedVertex::pos(Time time) const
 {
     VertexCellSet set = vertices();
     set << beforeVertex() << afterVertex();
-    foreach(VertexCell * v, set)
+    for(VertexCell * v: set)
     {
         if(v->exists(time))
             return v->pos(time);

--- a/src/VAC/VectorAnimationComplex/AnimatedVertex.cpp
+++ b/src/VAC/VectorAnimationComplex/AnimatedVertex.cpp
@@ -117,7 +117,7 @@ Eigen::Vector2d AnimatedVertex::pos(Time time) const
 {
     VertexCellSet set = vertices();
     set << beforeVertex() << afterVertex();
-    for(VertexCell * v: set)
+    for(VertexCell * v: qAsConst(set))
     {
         if(v->exists(time))
             return v->pos(time);

--- a/src/VAC/VectorAnimationComplex/Cell.cpp
+++ b/src/VAC/VectorAnimationComplex/Cell.cpp
@@ -481,7 +481,7 @@ CellSet Cell::spatialBoundary() const { return CellSet(); }
 CellSet Cell::spatialBoundary(Time t) const
 {
     CellSet res;
-    foreach(Cell * obj, this->spatialBoundary())
+    for(Cell * obj: this->spatialBoundary())
         if(obj->exists(t))
             res << obj;
     return res;
@@ -575,25 +575,25 @@ CellSet Cell::temporalNeighbourhoodAfter() const
 // -- Modifying star of boundary --
 void Cell::addMeToStarOfBoundary_()
 {
-    foreach(Cell * c, spatialBoundary())
+    for(Cell * c: spatialBoundary())
         addMeToSpatialStarOf_(c);
 
-    foreach(KeyCell * c, beforeCells())
+    for(KeyCell * c: beforeCells())
         addMeToTemporalStarAfterOf_(c);
 
-    foreach(KeyCell * c, afterCells())
+    for(KeyCell * c: afterCells())
         addMeToTemporalStarBeforeOf_(c);
 }
 
 void Cell::removeMeFromStarOfBoundary_()
 {
-    foreach(Cell * c, spatialBoundary())
+    for(Cell * c: spatialBoundary())
         removeMeFromSpatialStarOf_(c);
 
-    foreach(KeyCell * c, beforeCells())
+    for(KeyCell * c: beforeCells())
         removeMeFromTemporalStarAfterOf_(c);
 
-    foreach(KeyCell * c, afterCells())
+    for(KeyCell * c: afterCells())
         removeMeFromTemporalStarBeforeOf_(c);
 }
 
@@ -839,7 +839,7 @@ bool Cell::intersects(Time t, const BoundingBox & bb) const
 void Cell::processGeometryChanged_()
 {
     CellSet toClearCells = geometryDependentCells_();
-    foreach(Cell * cell, toClearCells)
+    for(Cell * cell: toClearCells)
         cell->clearCachedGeometry_();
 }
 

--- a/src/VAC/VectorAnimationComplex/Cell.cpp
+++ b/src/VAC/VectorAnimationComplex/Cell.cpp
@@ -481,7 +481,8 @@ CellSet Cell::spatialBoundary() const { return CellSet(); }
 CellSet Cell::spatialBoundary(Time t) const
 {
     CellSet res;
-    for(Cell * obj: this->spatialBoundary())
+    const auto& spatialBoundaryCells = this->spatialBoundary();
+    for(Cell * obj: spatialBoundaryCells)
         if(obj->exists(t))
             res << obj;
     return res;
@@ -575,25 +576,31 @@ CellSet Cell::temporalNeighbourhoodAfter() const
 // -- Modifying star of boundary --
 void Cell::addMeToStarOfBoundary_()
 {
-    for(Cell * c: spatialBoundary())
+    const auto& spatialBoundaryCells = spatialBoundary();
+    for(Cell * c: spatialBoundaryCells)
         addMeToSpatialStarOf_(c);
 
-    for(KeyCell * c: beforeCells())
+    const auto& beforeKeyCells = beforeCells();
+    for(KeyCell * c: beforeKeyCells)
         addMeToTemporalStarAfterOf_(c);
 
-    for(KeyCell * c: afterCells())
+    const auto& afterKeyCells = afterCells();
+    for(KeyCell * c: afterKeyCells)
         addMeToTemporalStarBeforeOf_(c);
 }
 
 void Cell::removeMeFromStarOfBoundary_()
 {
-    for(Cell * c: spatialBoundary())
+    const auto& spatialBoundaryCells = spatialBoundary();
+    for(Cell * c: spatialBoundaryCells)
         removeMeFromSpatialStarOf_(c);
 
-    for(KeyCell * c: beforeCells())
+    const auto& beforeKeyCells = beforeCells();
+    for(KeyCell * c: beforeKeyCells)
         removeMeFromTemporalStarAfterOf_(c);
 
-    for(KeyCell * c: afterCells())
+    const auto& afterKeyCells = afterCells();
+    for(KeyCell * c: afterKeyCells)
         removeMeFromTemporalStarBeforeOf_(c);
 }
 

--- a/src/VAC/VectorAnimationComplex/CellList.h
+++ b/src/VAC/VectorAnimationComplex/CellList.h
@@ -55,7 +55,7 @@ template<class U, class UContainer, class T, class TContainer>
 void copyCellContainer(const UContainer & from, TContainer & to)
 {
     to.clear();
-    foreach(U * u, from)
+    for(U * u: from)
     {
         if(u)
         {

--- a/src/VAC/VectorAnimationComplex/Cycle.cpp
+++ b/src/VAC/VectorAnimationComplex/Cycle.cpp
@@ -107,7 +107,7 @@ Cycle::Cycle(const KeyEdgeSet & edgeSetConst) :
     // if not all edges at same time, then invalid
     KeyEdge * first = *edgeSetConst.begin();
     Time t = first->time();
-    foreach(KeyEdge * iedge, edgeSetConst)
+    for(KeyEdge * iedge: edgeSetConst)
     {
         if(iedge->time() != t)
         {
@@ -192,7 +192,7 @@ Cycle::Cycle(const KeyEdgeSet & edgeSetConst) :
 
         // Check that it's simple
         KeyVertexSet vertices;
-        foreach(KeyHalfedge he, halfedges_)
+        for(KeyHalfedge he: halfedges_)
         {
             KeyVertex * vertex = he.startVertex();
             if(vertices.contains(vertex))
@@ -328,7 +328,7 @@ void Cycle::replaceEdges(KeyEdge * oldEdge, const KeyEdgeList & newEdges)
 {
     QList<KeyHalfedge> newHalfedges;
 
-    foreach(KeyHalfedge he, halfedges_)
+    for(KeyHalfedge he: halfedges_)
     {
         if(he.edge == oldEdge)
         {
@@ -383,7 +383,7 @@ double Cycle::length() const
     else
     {
         double res = 0;
-        foreach(KeyHalfedge he, halfedges_)
+        for(KeyHalfedge he: halfedges_)
             res += he.edge->geometry()->length();
         return res;
     }

--- a/src/VAC/VectorAnimationComplex/Cycle.cpp
+++ b/src/VAC/VectorAnimationComplex/Cycle.cpp
@@ -192,7 +192,7 @@ Cycle::Cycle(const KeyEdgeSet & edgeSetConst) :
 
         // Check that it's simple
         KeyVertexSet vertices;
-        for(KeyHalfedge he: halfedges_)
+        for(KeyHalfedge he: qAsConst(halfedges_))
         {
             KeyVertex * vertex = he.startVertex();
             if(vertices.contains(vertex))
@@ -328,7 +328,7 @@ void Cycle::replaceEdges(KeyEdge * oldEdge, const KeyEdgeList & newEdges)
 {
     QList<KeyHalfedge> newHalfedges;
 
-    for(KeyHalfedge he: halfedges_)
+    for(KeyHalfedge he: qAsConst(halfedges_))
     {
         if(he.edge == oldEdge)
         {

--- a/src/VAC/VectorAnimationComplex/CycleHelper.cpp
+++ b/src/VAC/VectorAnimationComplex/CycleHelper.cpp
@@ -146,7 +146,7 @@ CycleHelper::CycleHelper(const KeyEdgeSet & edgeSetConst) :
         QMap<KeyVertex*, Vertex*> vertexToNode;
         // /!\ be careful of memory leaks from here
 
-        for(KeyEdge * iedge: edgeSet)
+        for(KeyEdge * iedge: qAsConst(edgeSet))
         {
             // detect pure loop here, and abort if any
             if(iedge->isClosed())
@@ -201,7 +201,7 @@ CycleHelper::CycleHelper(const KeyEdgeSet & edgeSetConst) :
             Edge * edge = toProcess.top();
             toProcess.pop();
 
-            for(Edge * neighbour: edge->leftNode->edges)
+            for(Edge * neighbour: qAsConst(edge->leftNode->edges))
             {
                 if(!neighbour->marked)
                 {
@@ -209,7 +209,7 @@ CycleHelper::CycleHelper(const KeyEdgeSet & edgeSetConst) :
                     toProcess.push(neighbour);
                 }
             }
-            for(Edge * neighbour: edge->rightNode->edges)
+            for(Edge * neighbour: qAsConst(edge->rightNode->edges))
             {
                 if(!neighbour->marked)
                 {
@@ -218,16 +218,16 @@ CycleHelper::CycleHelper(const KeyEdgeSet & edgeSetConst) :
                 }
             }
         }
-        for(Edge * edge: subcomplexEdges)
+        for(Edge * edge: qAsConst(subcomplexEdges))
         {
             if(!edge->marked)
             {
                 //QMessageBox::information(0, QObject::tr("operation aborted"),
                 //                         QObject::tr("the selected edges are not all connected together"));
 
-                for(Edge * edge: subcomplexEdges)
+                for(Edge * edge: qAsConst(subcomplexEdges))
                     delete edge;
-                for(Vertex * node: subcomplexNodes)
+                for(Vertex * node: qAsConst(subcomplexNodes))
                     delete node;
 
                 return;
@@ -242,7 +242,7 @@ CycleHelper::CycleHelper(const KeyEdgeSet & edgeSetConst) :
         while (!subcomplexEdges.isEmpty())
         {
             //  initialization
-            for(Vertex * node: subcomplexNodes)
+            for(Vertex * node: qAsConst(subcomplexNodes))
             {
                 node->parent = 0;
                 node->isRoot = false;
@@ -255,7 +255,7 @@ CycleHelper::CycleHelper(const KeyEdgeSet & edgeSetConst) :
             {
                 // find a node that has not been visited yet, if any
                 Vertex * notYetVisitedNode = 0;
-                for(Vertex * node: subcomplexNodes)
+                for(Vertex * node: qAsConst(subcomplexNodes))
                 {
                     if(!node->visited)
                     {
@@ -281,7 +281,7 @@ CycleHelper::CycleHelper(const KeyEdgeSet & edgeSetConst) :
                     node->visited = true;
 
                     // depth-first recursive call: check all children
-                    for(Edge * incidentEdge: node->edges)
+                    for(Edge * incidentEdge: qAsConst(node->edges))
                     {
                         if(incidentEdge != node->parent) // do not check parent
                         {
@@ -308,7 +308,7 @@ CycleHelper::CycleHelper(const KeyEdgeSet & edgeSetConst) :
                                 // remove them from the subcomplex and add them to the list
                                 // of instant edges in the loop
                                 KeyEdgeSet iedgesInLoop;
-                                for(Edge * edge: edgesInLoop)
+                                for(Edge * edge: qAsConst(edgesInLoop))
                                 {
                                     // disconnect edge from left and right vertices
                                     Vertex * leftNode = edge->leftNode;
@@ -375,7 +375,7 @@ CycleHelper::CycleHelper(const KeyEdgeSet & edgeSetConst) :
 
         // find paths
         // for now, very trivial method: each remaining edge becomes a path
-        for(Edge * edge: subcomplexEdges)
+        for(Edge * edge: qAsConst(subcomplexEdges))
         {
             KeyCellSet set;
             set << edge->edge;
@@ -384,9 +384,9 @@ CycleHelper::CycleHelper(const KeyEdgeSet & edgeSetConst) :
         }
 
         // release memory
-        for(Edge * edge: subcomplexEdges)
+        for(Edge * edge: qAsConst(subcomplexEdges))
             delete edge;
-        for(Vertex * node: subcomplexNodes)
+        for(Vertex * node: qAsConst(subcomplexNodes))
             delete node;
 
         // ---- Now, check that the hole is valid ----

--- a/src/VAC/VectorAnimationComplex/CycleHelper.cpp
+++ b/src/VAC/VectorAnimationComplex/CycleHelper.cpp
@@ -55,7 +55,7 @@ CycleHelper::CycleHelper(const KeyEdgeSet & edgeSetConst) :
     // if not all edges at same time, then invalid
     KeyEdge * first = *edgeSetConst.begin();
     Time t = first->time();
-    foreach(KeyEdge * iedge, edgeSetConst)
+    for(KeyEdge * iedge: edgeSetConst)
     {
         if(iedge->time() != t)
         {
@@ -146,7 +146,7 @@ CycleHelper::CycleHelper(const KeyEdgeSet & edgeSetConst) :
         QMap<KeyVertex*, Vertex*> vertexToNode;
         // /!\ be careful of memory leaks from here
 
-        foreach(KeyEdge * iedge, edgeSet)
+        for(KeyEdge * iedge: edgeSet)
         {
             // detect pure loop here, and abort if any
             if(iedge->isClosed())
@@ -154,9 +154,9 @@ CycleHelper::CycleHelper(const KeyEdgeSet & edgeSetConst) :
                 //QMessageBox::information(0, QObject::tr("operation aborted"),
                 //                         QObject::tr("more than one edge and one of them is a pure loop"));
 
-                foreach(Edge * edge, subcomplexEdges)
+                for(Edge * edge: subcomplexEdges)
                     delete edge;
-                foreach(Vertex * node, subcomplexNodes)
+                for(Vertex * node: subcomplexNodes)
                     delete node;
 
                 return;
@@ -201,7 +201,7 @@ CycleHelper::CycleHelper(const KeyEdgeSet & edgeSetConst) :
             Edge * edge = toProcess.top();
             toProcess.pop();
 
-            foreach(Edge * neighbour, edge->leftNode->edges)
+            for(Edge * neighbour: edge->leftNode->edges)
             {
                 if(!neighbour->marked)
                 {
@@ -209,7 +209,7 @@ CycleHelper::CycleHelper(const KeyEdgeSet & edgeSetConst) :
                     toProcess.push(neighbour);
                 }
             }
-            foreach(Edge * neighbour, edge->rightNode->edges)
+            for(Edge * neighbour: edge->rightNode->edges)
             {
                 if(!neighbour->marked)
                 {
@@ -218,16 +218,16 @@ CycleHelper::CycleHelper(const KeyEdgeSet & edgeSetConst) :
                 }
             }
         }
-        foreach(Edge * edge, subcomplexEdges)
+        for(Edge * edge: subcomplexEdges)
         {
             if(!edge->marked)
             {
                 //QMessageBox::information(0, QObject::tr("operation aborted"),
                 //                         QObject::tr("the selected edges are not all connected together"));
 
-                foreach(Edge * edge, subcomplexEdges)
+                for(Edge * edge: subcomplexEdges)
                     delete edge;
-                foreach(Vertex * node, subcomplexNodes)
+                for(Vertex * node: subcomplexNodes)
                     delete node;
 
                 return;
@@ -242,7 +242,7 @@ CycleHelper::CycleHelper(const KeyEdgeSet & edgeSetConst) :
         while (!subcomplexEdges.isEmpty())
         {
             //  initialization
-            foreach(Vertex * node, subcomplexNodes)
+            for(Vertex * node: subcomplexNodes)
             {
                 node->parent = 0;
                 node->isRoot = false;
@@ -255,7 +255,7 @@ CycleHelper::CycleHelper(const KeyEdgeSet & edgeSetConst) :
             {
                 // find a node that has not been visited yet, if any
                 Vertex * notYetVisitedNode = 0;
-                foreach(Vertex * node, subcomplexNodes)
+                for(Vertex * node: subcomplexNodes)
                 {
                     if(!node->visited)
                     {
@@ -281,7 +281,7 @@ CycleHelper::CycleHelper(const KeyEdgeSet & edgeSetConst) :
                     node->visited = true;
 
                     // depth-first recursive call: check all children
-                    foreach(Edge * incidentEdge, node->edges)
+                    for(Edge * incidentEdge: node->edges)
                     {
                         if(incidentEdge != node->parent) // do not check parent
                         {
@@ -308,7 +308,7 @@ CycleHelper::CycleHelper(const KeyEdgeSet & edgeSetConst) :
                                 // remove them from the subcomplex and add them to the list
                                 // of instant edges in the loop
                                 KeyEdgeSet iedgesInLoop;
-                                foreach(Edge * edge, edgesInLoop)
+                                for(Edge * edge: edgesInLoop)
                                 {
                                     // disconnect edge from left and right vertices
                                     Vertex * leftNode = edge->leftNode;
@@ -375,7 +375,7 @@ CycleHelper::CycleHelper(const KeyEdgeSet & edgeSetConst) :
 
         // find paths
         // for now, very trivial method: each remaining edge becomes a path
-        foreach(Edge * edge, subcomplexEdges)
+        for(Edge * edge: subcomplexEdges)
         {
             KeyCellSet set;
             set << edge->edge;
@@ -384,9 +384,9 @@ CycleHelper::CycleHelper(const KeyEdgeSet & edgeSetConst) :
         }
 
         // release memory
-        foreach(Edge * edge, subcomplexEdges)
+        for(Edge * edge: subcomplexEdges)
             delete edge;
-        foreach(Vertex * node, subcomplexNodes)
+        for(Vertex * node: subcomplexNodes)
             delete node;
 
         // ---- Now, check that the hole is valid ----

--- a/src/VAC/VectorAnimationComplex/EdgeCell.cpp
+++ b/src/VAC/VectorAnimationComplex/EdgeCell.cpp
@@ -116,10 +116,14 @@ CellSet EdgeCell::spatialBoundary() const
 EdgeCellSet EdgeCell::incidentEdges() const
 {
     CellSet incidentCells;
-    for(Cell * c: spatialBoundary())
-        for(Cell * d: c->spatialStar())
+    const auto& spatialBoundaryObjects = spatialBoundary();
+    for(Cell * c: spatialBoundaryObjects)
+    {
+        const auto& spatialStarObjects = c->spatialStar();
+        for(Cell * d: spatialStarObjects)
             if(d != this)
             incidentCells << d;
+    }
     return incidentCells;
 }
 

--- a/src/VAC/VectorAnimationComplex/EdgeCell.cpp
+++ b/src/VAC/VectorAnimationComplex/EdgeCell.cpp
@@ -116,8 +116,8 @@ CellSet EdgeCell::spatialBoundary() const
 EdgeCellSet EdgeCell::incidentEdges() const
 {
     CellSet incidentCells;
-    foreach(Cell * c, spatialBoundary())
-        foreach(Cell * d, c->spatialStar())
+    for(Cell * c: spatialBoundary())
+        for(Cell * d: c->spatialStar())
             if(d != this)
             incidentCells << d;
     return incidentCells;

--- a/src/VAC/VectorAnimationComplex/EdgeGeometry.cpp
+++ b/src/VAC/VectorAnimationComplex/EdgeGeometry.cpp
@@ -386,7 +386,7 @@ LinearSpline::LinearSpline(const std::vector<EdgeSample,Eigen::aligned_allocator
 LinearSpline::LinearSpline(const QList<EdgeSample> & samples, bool loop)
 {
     std::vector<EdgeSample,Eigen::aligned_allocator<EdgeSample> > stdvector;
-    foreach (EdgeSample es, samples)
+    for (EdgeSample es: samples)
     {
         stdvector.push_back(es);
     }

--- a/src/VAC/VectorAnimationComplex/InbetweenEdge.cpp
+++ b/src/VAC/VectorAnimationComplex/InbetweenEdge.cpp
@@ -94,13 +94,17 @@ InbetweenEdge::InbetweenEdge(VAC * vac,
     assert(afterPath_.endVertex() == endAnimatedVertex_.afterVertex());
 
     // Cache star
-    for(VertexCell * vertex: startVertices())
+    const auto& startCellVertices = startVertices();
+    for(VertexCell * vertex: startCellVertices)
         addMeToSpatialStarOf_(vertex);
-    for(VertexCell * vertex: endVertices())
+    const auto& endCellVertices = endVertices();
+    for(VertexCell * vertex: endCellVertices)
         addMeToSpatialStarOf_(vertex);
-    for(KeyCell * kcell: beforeCells())
+    const auto& beforeKeyCells= beforeCells();
+    for(KeyCell * kcell: beforeKeyCells)
         addMeToTemporalStarAfterOf_(kcell);
-    for(KeyCell * kcell: afterCells())
+    const auto& afterKeyCells= afterCells();
+    for(KeyCell * kcell: afterKeyCells)
         addMeToTemporalStarBeforeOf_(kcell);
 }
 
@@ -120,9 +124,11 @@ InbetweenEdge::InbetweenEdge(VAC * vac,
     assert(beforeCycle_.time() < afterCycle_.time());
 
     // Cache star
-    for(KeyCell * kcell: beforeCells())
+    const auto& beforeKeyCells= beforeCells();
+    for(KeyCell * kcell: beforeKeyCells)
         addMeToTemporalStarAfterOf_(kcell);
-    for(KeyCell * kcell: afterCells())
+    const auto& afterKeyCells= afterCells();
+    for(KeyCell * kcell: afterKeyCells)
         addMeToTemporalStarBeforeOf_(kcell);
 }
 
@@ -307,7 +313,8 @@ InbetweenEdge::InbetweenEdge(VAC * vac, XmlStreamReader & xml) :
 
     VertexCell * InbetweenEdge::startVertex(Time time) const
     {
-        for(VertexCell * v: startVertices())
+        const auto& startCellVertices = startVertices();
+        for(VertexCell * v: startCellVertices)
             if(v->exists(time))
                 return v;
         return 0;
@@ -315,7 +322,8 @@ InbetweenEdge::InbetweenEdge(VAC * vac, XmlStreamReader & xml) :
 
     VertexCell * InbetweenEdge::endVertex(Time time) const
     {
-        for(VertexCell * v: endVertices())
+        const auto& endCellVertices = endVertices();
+        for(VertexCell * v: endCellVertices)
             if(v->exists(time))
                 return v;
         return 0;

--- a/src/VAC/VectorAnimationComplex/InbetweenEdge.cpp
+++ b/src/VAC/VectorAnimationComplex/InbetweenEdge.cpp
@@ -94,13 +94,13 @@ InbetweenEdge::InbetweenEdge(VAC * vac,
     assert(afterPath_.endVertex() == endAnimatedVertex_.afterVertex());
 
     // Cache star
-    foreach(VertexCell * vertex, startVertices())
+    for(VertexCell * vertex: startVertices())
         addMeToSpatialStarOf_(vertex);
-    foreach(VertexCell * vertex, endVertices())
+    for(VertexCell * vertex: endVertices())
         addMeToSpatialStarOf_(vertex);
-    foreach(KeyCell * kcell, beforeCells())
+    for(KeyCell * kcell: beforeCells())
         addMeToTemporalStarAfterOf_(kcell);
-    foreach(KeyCell * kcell, afterCells())
+    for(KeyCell * kcell: afterCells())
         addMeToTemporalStarBeforeOf_(kcell);
 }
 
@@ -120,9 +120,9 @@ InbetweenEdge::InbetweenEdge(VAC * vac,
     assert(beforeCycle_.time() < afterCycle_.time());
 
     // Cache star
-    foreach(KeyCell * kcell, beforeCells())
+    for(KeyCell * kcell: beforeCells())
         addMeToTemporalStarAfterOf_(kcell);
-    foreach(KeyCell * kcell, afterCells())
+    for(KeyCell * kcell: afterCells())
         addMeToTemporalStarBeforeOf_(kcell);
 }
 
@@ -307,7 +307,7 @@ InbetweenEdge::InbetweenEdge(VAC * vac, XmlStreamReader & xml) :
 
     VertexCell * InbetweenEdge::startVertex(Time time) const
     {
-        foreach(VertexCell * v, startVertices())
+        for(VertexCell * v: startVertices())
             if(v->exists(time))
                 return v;
         return 0;
@@ -315,7 +315,7 @@ InbetweenEdge::InbetweenEdge(VAC * vac, XmlStreamReader & xml) :
 
     VertexCell * InbetweenEdge::endVertex(Time time) const
     {
-        foreach(VertexCell * v, endVertices())
+        for(VertexCell * v: endVertices())
             if(v->exists(time))
                 return v;
         return 0;

--- a/src/VAC/VectorAnimationComplex/InbetweenFace.cpp
+++ b/src/VAC/VectorAnimationComplex/InbetweenFace.cpp
@@ -540,12 +540,12 @@ void InbetweenFace::read2ndPass()
 
     // Before faces
     beforeFaces_.clear();
-    foreach(int id, tempBeforeFaces_)
+    for(int id: tempBeforeFaces_)
         beforeFaces_ << vac()->getCell(id)->toKeyFace();
 
     // After faces
     afterFaces_.clear();
-    foreach(int id, tempAfterFaces_)
+    for(int id: tempAfterFaces_)
         afterFaces_ << vac()->getCell(id)->toKeyFace();
 }
 
@@ -563,7 +563,7 @@ void InbetweenFace::save_(QTextStream & out)
     out << Save::newField("BeforeFaces");
     out << "[";
     bool first = true;
-    foreach(KeyFace * face, beforeFaces_)
+    for(KeyFace * face: beforeFaces_)
     {
         if(first)
             first = false;
@@ -577,7 +577,7 @@ void InbetweenFace::save_(QTextStream & out)
     out << Save::newField("AfterFaces");
     out << "[";
     first = true;
-    foreach(KeyFace * face, afterFaces_)
+    for(KeyFace * face: afterFaces_)
     {
         if(first)
             first = false;
@@ -613,7 +613,7 @@ void InbetweenFace::write_(XmlStreamWriter & xml) const
     // Before faces
     QString beforeFacesString;
     bool first = true;
-    foreach(KeyFace * face, beforeFaces_)
+    for(KeyFace * face: beforeFaces_)
     {
         if(first)
             first = false;
@@ -627,7 +627,7 @@ void InbetweenFace::write_(XmlStreamWriter & xml) const
     // After faces
     QString afterFacesString;
     first = true;
-    foreach(KeyFace * face, afterFaces_)
+    for(KeyFace * face: afterFaces_)
     {
         if(first)
             first = false;
@@ -698,13 +698,13 @@ void InbetweenFace::remapPointers(VAC * newVAC)
 
     // Before faces
     QSet<KeyFace*> newBeforeFaces;
-    foreach(KeyFace * face, beforeFaces_)
+    for(KeyFace * face: beforeFaces_)
         newBeforeFaces << vac()->getCell(face->id())->toKeyFace();
     beforeFaces_ = newBeforeFaces;
 
     // After faces
     QSet<KeyFace*> newAfterFaces;
-    foreach(KeyFace * face, afterFaces_)
+    for(KeyFace * face: afterFaces_)
         newAfterFaces << vac()->getCell(face->id())->toKeyFace();
     afterFaces_ = newAfterFaces;
 }

--- a/src/VAC/VectorAnimationComplex/InbetweenFace.cpp
+++ b/src/VAC/VectorAnimationComplex/InbetweenFace.cpp
@@ -540,12 +540,12 @@ void InbetweenFace::read2ndPass()
 
     // Before faces
     beforeFaces_.clear();
-    for(int id: tempBeforeFaces_)
+    for(int id: qAsConst(tempBeforeFaces_))
         beforeFaces_ << vac()->getCell(id)->toKeyFace();
 
     // After faces
     afterFaces_.clear();
-    for(int id: tempAfterFaces_)
+    for(int id: qAsConst(tempAfterFaces_))
         afterFaces_ << vac()->getCell(id)->toKeyFace();
 }
 
@@ -563,7 +563,7 @@ void InbetweenFace::save_(QTextStream & out)
     out << Save::newField("BeforeFaces");
     out << "[";
     bool first = true;
-    for(KeyFace * face: beforeFaces_)
+    for(KeyFace * face: qAsConst(beforeFaces_))
     {
         if(first)
             first = false;
@@ -577,7 +577,7 @@ void InbetweenFace::save_(QTextStream & out)
     out << Save::newField("AfterFaces");
     out << "[";
     first = true;
-    for(KeyFace * face: afterFaces_)
+    for(KeyFace * face: qAsConst(afterFaces_))
     {
         if(first)
             first = false;
@@ -698,13 +698,13 @@ void InbetweenFace::remapPointers(VAC * newVAC)
 
     // Before faces
     QSet<KeyFace*> newBeforeFaces;
-    for(KeyFace * face: beforeFaces_)
+    for(KeyFace * face: qAsConst(beforeFaces_))
         newBeforeFaces << vac()->getCell(face->id())->toKeyFace();
     beforeFaces_ = newBeforeFaces;
 
     // After faces
     QSet<KeyFace*> newAfterFaces;
-    for(KeyFace * face: afterFaces_)
+    for(KeyFace * face: qAsConst(afterFaces_))
         newAfterFaces << vac()->getCell(face->id())->toKeyFace();
     afterFaces_ = newAfterFaces;
 }

--- a/src/VAC/VectorAnimationComplex/KeyCell.cpp
+++ b/src/VAC/VectorAnimationComplex/KeyCell.cpp
@@ -48,7 +48,7 @@ Time KeyCell::temporalDragMinTime() const
     Time res(-1000); // TODO
 
     InbetweenCellSet beforeStar = temporalStarBefore();
-    foreach(InbetweenCell * scell, beforeStar)
+    for(InbetweenCell * scell: beforeStar)
     {
         Time t = scell->beforeTime();
         if(res < t)
@@ -65,7 +65,7 @@ Time KeyCell::temporalDragMaxTime() const
 
 
     InbetweenCellSet afterStar = temporalStarAfter();
-    foreach(InbetweenCell * scell, afterStar)
+    for(InbetweenCell * scell: afterStar)
     {
         Time t = scell->afterTime();
         if(t < res)

--- a/src/VAC/VectorAnimationComplex/KeyEdge.cpp
+++ b/src/VAC/VectorAnimationComplex/KeyEdge.cpp
@@ -370,7 +370,7 @@ void KeyEdge::prepareSculptPreserveTangents_()
         {
             KeyEdgeSet leftEdges =  startVertex_->spatialStar();
             leftEdges.remove(this);
-            foreach(KeyEdge * ie, leftEdges)
+            for(KeyEdge * ie: leftEdges)
             {
                 if(ie->endVertex_ == startVertex_)
                 {
@@ -392,7 +392,7 @@ void KeyEdge::prepareSculptPreserveTangents_()
         {
             KeyEdgeSet rightEdges =  endVertex_->spatialStar();
             rightEdges.remove(this);
-            foreach(KeyEdge * ie, rightEdges)
+            for(KeyEdge * ie: rightEdges)
             {
                 // For now, disabling tangent preservation for 0-edge loops
                 if(ie == this)
@@ -445,13 +445,13 @@ void KeyEdge::continueSculptPreserveTangents_()
     // preserve tangency
     Eigen::Vector2d continueLeftDer = geometry()->der(0);
     Eigen::Vector2d continueRightDer = geometry()->der(geometry()->length());
-    foreach(KeyEdge * ie, sculpt_keepRightAsLeft_)
+    for(KeyEdge * ie: sculpt_keepRightAsLeft_)
         ie->geometry()->setRightDer(continueLeftDer, remainingRadiusLeft_, true);
-    foreach(KeyEdge * ie, sculpt_keepLeftAsLeft_)
+    for(KeyEdge * ie: sculpt_keepLeftAsLeft_)
         ie->geometry()->setLeftDer(-continueLeftDer, remainingRadiusLeft_, true);
-    foreach(KeyEdge * ie, sculpt_keepLeftAsRight_)
+    for(KeyEdge * ie: sculpt_keepLeftAsRight_)
         ie->geometry()->setLeftDer(continueRightDer, remainingRadiusRight_, true);
-    foreach(KeyEdge * ie, sculpt_keepRightAsRight_)
+    for(KeyEdge * ie: sculpt_keepRightAsRight_)
         ie->geometry()->setRightDer(-continueRightDer, remainingRadiusRight_, true);
     if(sculpt_keepMyselfTangent_)
     {

--- a/src/VAC/VectorAnimationComplex/KeyEdge.cpp
+++ b/src/VAC/VectorAnimationComplex/KeyEdge.cpp
@@ -445,13 +445,13 @@ void KeyEdge::continueSculptPreserveTangents_()
     // preserve tangency
     Eigen::Vector2d continueLeftDer = geometry()->der(0);
     Eigen::Vector2d continueRightDer = geometry()->der(geometry()->length());
-    for(KeyEdge * ie: sculpt_keepRightAsLeft_)
+    for(KeyEdge * ie: qAsConst(sculpt_keepRightAsLeft_))
         ie->geometry()->setRightDer(continueLeftDer, remainingRadiusLeft_, true);
-    for(KeyEdge * ie: sculpt_keepLeftAsLeft_)
+    for(KeyEdge * ie: qAsConst(sculpt_keepLeftAsLeft_))
         ie->geometry()->setLeftDer(-continueLeftDer, remainingRadiusLeft_, true);
-    for(KeyEdge * ie: sculpt_keepLeftAsRight_)
+    for(KeyEdge * ie: qAsConst(sculpt_keepLeftAsRight_))
         ie->geometry()->setLeftDer(continueRightDer, remainingRadiusRight_, true);
-    for(KeyEdge * ie: sculpt_keepRightAsRight_)
+    for(KeyEdge * ie: qAsConst(sculpt_keepRightAsRight_))
         ie->geometry()->setRightDer(-continueRightDer, remainingRadiusRight_, true);
     if(sculpt_keepMyselfTangent_)
     {

--- a/src/VAC/VectorAnimationComplex/KeyFace.cpp
+++ b/src/VAC/VectorAnimationComplex/KeyFace.cpp
@@ -378,7 +378,7 @@ void KeyFace::initColor_()
 
 void KeyFace::clearCycles_()
 {
-    foreach(Cell * cell, spatialBoundary())
+    for(Cell * cell: spatialBoundary())
         removeMeFromSpatialStarOf_(cell);
 
     cycles_.clear();
@@ -400,7 +400,7 @@ void KeyFace::addCycles(const QList<Cycle> & cycles)
 void KeyFace::addCycle(const Cycle & cycle)
 {
     cycles_ << cycle;
-    foreach(KeyCell * cell, cycle.cells())
+    for(KeyCell * cell: cycle.cells())
         addMeToSpatialStarOf_(cell);
     processGeometryChanged_();
 }

--- a/src/VAC/VectorAnimationComplex/KeyFace.cpp
+++ b/src/VAC/VectorAnimationComplex/KeyFace.cpp
@@ -378,7 +378,8 @@ void KeyFace::initColor_()
 
 void KeyFace::clearCycles_()
 {
-    for(Cell * cell: spatialBoundary())
+    const auto& spatialBoundaryCells = spatialBoundary();
+    for(Cell * cell: spatialBoundaryCells)
         removeMeFromSpatialStarOf_(cell);
 
     cycles_.clear();
@@ -400,7 +401,8 @@ void KeyFace::addCycles(const QList<Cycle> & cycles)
 void KeyFace::addCycle(const Cycle & cycle)
 {
     cycles_ << cycle;
-    for(KeyCell * cell: cycle.cells())
+    const auto& keyCycleCells = cycle.cells();
+    for(KeyCell * cell: keyCycleCells)
         addMeToSpatialStarOf_(cell);
     processGeometryChanged_();
 }

--- a/src/VAC/VectorAnimationComplex/KeyHalfedge.cpp
+++ b/src/VAC/VectorAnimationComplex/KeyHalfedge.cpp
@@ -171,7 +171,7 @@ QList<KeyHalfedge> KeyHalfedge::sorted(const QList<KeyHalfedge> & adj)
 
     // return the he sorted
     QList<KeyHalfedge> res;
-    for(KeyAngleHalfEdge ahe: list)
+    for(KeyAngleHalfEdge ahe: qAsConst(list))
         res << ahe.he;
     return res;
 }

--- a/src/VAC/VectorAnimationComplex/KeyHalfedge.cpp
+++ b/src/VAC/VectorAnimationComplex/KeyHalfedge.cpp
@@ -116,7 +116,7 @@ QList<KeyHalfedge> KeyHalfedge::endIncidentHalfEdges()
     KeyVertex * v = endVertex();
     KeyEdgeSet edges = v->star();
     QList<KeyHalfedge> halfedges;
-    foreach(KeyEdge * e, edges)
+    for(KeyEdge * e: edges)
     {
         if(e->startVertex() == v)
             halfedges << KeyHalfedge(e,true);
@@ -160,7 +160,7 @@ QList<KeyHalfedge> KeyHalfedge::sorted(const QList<KeyHalfedge> & adj)
     // compute all the angles between this he to the others
     Eigen::Vector2d u = - rightDer();
     QList<KeyAngleHalfEdge> list;
-    foreach(KeyHalfedge he, adj)
+    for(KeyHalfedge he: adj)
     {
         double angle = GeometryUtils::angleLike(u, he.leftDer());
         list << KeyAngleHalfEdge(he, angle);
@@ -171,7 +171,7 @@ QList<KeyHalfedge> KeyHalfedge::sorted(const QList<KeyHalfedge> & adj)
 
     // return the he sorted
     QList<KeyHalfedge> res;
-    foreach(KeyAngleHalfEdge ahe, list)
+    for(KeyAngleHalfEdge ahe: list)
         res << ahe.he;
     return res;
 }

--- a/src/VAC/VectorAnimationComplex/KeyVertex.cpp
+++ b/src/VAC/VectorAnimationComplex/KeyVertex.cpp
@@ -221,7 +221,7 @@ void KeyVertex::computePosFromEdges()
     Eigen::Vector2d res(0,0);
 
     int n = 0;
-    foreach(Cell * c, ss)
+    for(Cell * c: ss)
     {
         KeyEdge * iedge = c->toKeyEdge();
         if(iedge)
@@ -248,7 +248,7 @@ void KeyVertex::correctEdgesGeometry()
 {
     CellSet ss = spatialStar();
 
-    foreach(Cell * c, ss)
+    for(Cell * c: ss)
     {
         KeyEdge * iedge = c->toKeyEdge();
         if(iedge)
@@ -265,7 +265,7 @@ KeyVertexList KeyVertex::beforeVertices() const
 {
     InbetweenVertexSet beforeAN = temporalStarBefore();
     KeyVertexList res;
-    foreach(InbetweenVertex * node, beforeAN)
+    for(InbetweenVertex * node: beforeAN)
         res << node->beforeVertex();
     return res;
 }
@@ -274,7 +274,7 @@ KeyVertexList KeyVertex::afterVertices() const
 {
     InbetweenVertexSet afterAN = temporalStarAfter();
     KeyVertexList res;
-    foreach(InbetweenVertex * node, afterAN)
+    for(InbetweenVertex * node: afterAN)
         res << node->afterVertex();
     return res;
 }
@@ -285,13 +285,13 @@ Eigen::Vector2d KeyVertex::catmullRomTangent(bool slowInOut) const
 
     KeyVertexList B = beforeVertices();
     KeyVertexList A = afterVertices();
-    foreach(KeyVertex * node, B)
+    for(KeyVertex * node: B)
     {
         Eigen::Vector2d dp = pos() - node->pos();
         double dt = time().floatTime() - node->time().floatTime();
         u += Eigen::Vector3d(dp[0],dp[1],dt);
     }
-    foreach(KeyVertex * node, A)
+    for(KeyVertex * node: A)
     {
         Eigen::Vector2d dp = node->pos() - pos();
         double dt = node->time().floatTime() - time().floatTime();
@@ -316,13 +316,13 @@ Eigen::Vector2d KeyVertex::dividedDifferencesTangent(bool slowInOut) const
     KeyVertexList A = afterVertices();
     int m = A.size();
 
-    foreach(KeyVertex * node, B)
+    for(KeyVertex * node: B)
     {
         Eigen::Vector2d dp = pos() - node->pos();
         double dt = time().floatTime() - node->time().floatTime();
         u += dp/dt;
     }
-    foreach(KeyVertex * node, A)
+    for(KeyVertex * node: A)
     {
         Eigen::Vector2d dp = node->pos() - pos();
         double dt = node->time().floatTime() - time().floatTime();

--- a/src/VAC/VectorAnimationComplex/Operator.cpp
+++ b/src/VAC/VectorAnimationComplex/Operator.cpp
@@ -85,7 +85,7 @@ void Operator::modify(VAC * vac)
 // check the validity
 bool Operator::check()
 {
-    foreach(VAC * vac, /*root_->*/modifiedVAC_)
+    for(VAC * vac: /*root_->*/modifiedVAC_)
         if(!vac->check())
         {
             qDebug() << "A VAC modified by the operator is not valid anymore.";
@@ -93,7 +93,7 @@ bool Operator::check()
         }
     /*root_->*/modifiedVAC_.clear();
 
-    foreach(Cell * c, /*root_->*/modifiedCells_)
+    for(Cell * c: /*root_->*/modifiedCells_)
         if(!c->check())
         {
             qDebug() << "Cell(" << c->id() << ") modified by the operator is not valid anymore.";

--- a/src/VAC/VectorAnimationComplex/Operator.cpp
+++ b/src/VAC/VectorAnimationComplex/Operator.cpp
@@ -85,7 +85,7 @@ void Operator::modify(VAC * vac)
 // check the validity
 bool Operator::check()
 {
-    for(VAC * vac: /*root_->*/modifiedVAC_)
+    for(VAC * vac: /*root_->*/qAsConst(modifiedVAC_))
         if(!vac->check())
         {
             qDebug() << "A VAC modified by the operator is not valid anymore.";
@@ -93,7 +93,7 @@ bool Operator::check()
         }
     /*root_->*/modifiedVAC_.clear();
 
-    for(Cell * c: /*root_->*/modifiedCells_)
+    for(Cell * c: /*root_->*/qAsConst(modifiedCells_))
         if(!c->check())
         {
             qDebug() << "Cell(" << c->id() << ") modified by the operator is not valid anymore.";

--- a/src/VAC/VectorAnimationComplex/Path.cpp
+++ b/src/VAC/VectorAnimationComplex/Path.cpp
@@ -92,7 +92,7 @@ Path::Path(const KeyEdgeSet & edgeSetConst) :
     // if not all edges at same time, then invalid
     KeyEdge * first = *edgeSetConst.begin();
     Time t = first->time();
-    foreach(KeyEdge * iedge, edgeSetConst)
+    for(KeyEdge * iedge: edgeSetConst)
     {
         if(iedge->time() != t)
         {
@@ -202,7 +202,7 @@ Path::Path(const KeyEdgeSet & edgeSetConst) :
 
         // Check that it's simple
         //KeyVertexSet vertices;
-        //foreach(KeyHalfEdge he, halfedges_)
+        //for(KeyHalfEdge he: halfedges_)
         //{
         //    KeyVertex * vertex = he.startVertex();
         //    if(vertices.contains(vertex))
@@ -442,7 +442,7 @@ void Path::replaceEdges(KeyEdge * oldEdge, const KeyEdgeList & newEdges)
 {
     QList<KeyHalfedge> newHalfedges;
 
-    foreach(KeyHalfedge he, halfedges_)
+    for(KeyHalfedge he: halfedges_)
     {
         if(he.edge == oldEdge)
         {
@@ -498,7 +498,7 @@ double Path::length() const
     else
     {
         double res = 0;
-        foreach(KeyHalfedge he, halfedges_)
+        for(KeyHalfedge he: halfedges_)
             res += he.edge->geometry()->length();
         return res;
     }

--- a/src/VAC/VectorAnimationComplex/Path.cpp
+++ b/src/VAC/VectorAnimationComplex/Path.cpp
@@ -442,7 +442,7 @@ void Path::replaceEdges(KeyEdge * oldEdge, const KeyEdgeList & newEdges)
 {
     QList<KeyHalfedge> newHalfedges;
 
-    for(KeyHalfedge he: halfedges_)
+    for(KeyHalfedge he: qAsConst(halfedges_))
     {
         if(he.edge == oldEdge)
         {

--- a/src/VAC/VectorAnimationComplex/ProperCycle.cpp
+++ b/src/VAC/VectorAnimationComplex/ProperCycle.cpp
@@ -38,7 +38,7 @@ ProperCycle::ProperCycle(const KeyEdgeSet & edgeSetConst)
     // if not all edges at same time, then invalid
     KeyEdge * first = *edgeSetConst.begin();
     Time t = first->time();
-    foreach(KeyEdge * iedge, edgeSetConst)
+    for(KeyEdge * iedge: edgeSetConst)
     {
         if(iedge->time() != t)
         {
@@ -123,7 +123,7 @@ ProperCycle::ProperCycle(const KeyEdgeSet & edgeSetConst)
 
         // Check that it's simple
         KeyVertexSet vertices;
-        foreach(KeyHalfedge he, halfedges_)
+        for(KeyHalfedge he: halfedges_)
         {
             KeyVertex * vertex = he.startVertex();
             if(vertices.contains(vertex))
@@ -180,7 +180,7 @@ void ProperCycle::replaceEdges(KeyEdge * oldEdge, const KeyEdgeList & newEdges)
 {
     QList<KeyHalfedge> newHalfedges;
 
-    foreach(KeyHalfedge he, halfedges_)
+    for(KeyHalfedge he: halfedges_)
     {
         if(he.edge == oldEdge)
         {

--- a/src/VAC/VectorAnimationComplex/ProperCycle.cpp
+++ b/src/VAC/VectorAnimationComplex/ProperCycle.cpp
@@ -123,7 +123,7 @@ ProperCycle::ProperCycle(const KeyEdgeSet & edgeSetConst)
 
         // Check that it's simple
         KeyVertexSet vertices;
-        for(KeyHalfedge he: halfedges_)
+        for(KeyHalfedge he: qAsConst(halfedges_))
         {
             KeyVertex * vertex = he.startVertex();
             if(vertices.contains(vertex))
@@ -180,7 +180,7 @@ void ProperCycle::replaceEdges(KeyEdge * oldEdge, const KeyEdgeList & newEdges)
 {
     QList<KeyHalfedge> newHalfedges;
 
-    for(KeyHalfedge he: halfedges_)
+    for(KeyHalfedge he: qAsConst(halfedges_))
     {
         if(he.edge == oldEdge)
         {

--- a/src/VAC/VectorAnimationComplex/ProperPath.cpp
+++ b/src/VAC/VectorAnimationComplex/ProperPath.cpp
@@ -127,7 +127,7 @@ ProperPath::ProperPath(const KeyEdgeSet & edgeSetConst)
 
     // Check that it's simple
     KeyVertexSet vertices;
-    for(KeyHalfedge he: halfedges_)
+    for(KeyHalfedge he: qAsConst(halfedges_))
     {
         KeyVertex * vertex = he.startVertex();
         if(vertices.contains(vertex))
@@ -175,7 +175,7 @@ void ProperPath::remapPointers(VAC * newVAC)
 void ProperPath::save(QTextStream & out)
 {
     out << "[ ";
-    for(KeyHalfedge he: halfedges_)
+    for(KeyHalfedge he: qAsConst(halfedges_))
     {
         he.save(out);
         out << " ";
@@ -194,7 +194,7 @@ void ProperPath::replaceEdges(KeyEdge * oldEdge, const KeyEdgeList & newEdges)
 {
     QList<KeyHalfedge> newHalfedges;
 
-    for(KeyHalfedge he: halfedges_)
+    for(KeyHalfedge he: qAsConst(halfedges_))
     {
         if(he.edge == oldEdge)
         {

--- a/src/VAC/VectorAnimationComplex/ProperPath.cpp
+++ b/src/VAC/VectorAnimationComplex/ProperPath.cpp
@@ -38,7 +38,7 @@ ProperPath::ProperPath(const KeyEdgeSet & edgeSetConst)
     // if not all edges at same time, then invalid
     KeyEdge * first = *edgeSetConst.begin();
     Time t = first->time();
-    foreach(KeyEdge * iedge, edgeSetConst)
+    for(KeyEdge * iedge: edgeSetConst)
     {
         if(iedge->time() != t)
         {
@@ -127,7 +127,7 @@ ProperPath::ProperPath(const KeyEdgeSet & edgeSetConst)
 
     // Check that it's simple
     KeyVertexSet vertices;
-    foreach(KeyHalfedge he, halfedges_)
+    for(KeyHalfedge he: halfedges_)
     {
         KeyVertex * vertex = he.startVertex();
         if(vertices.contains(vertex))
@@ -175,7 +175,7 @@ void ProperPath::remapPointers(VAC * newVAC)
 void ProperPath::save(QTextStream & out)
 {
     out << "[ ";
-    foreach(KeyHalfedge he, halfedges_)
+    for(KeyHalfedge he: halfedges_)
     {
         he.save(out);
         out << " ";
@@ -194,7 +194,7 @@ void ProperPath::replaceEdges(KeyEdge * oldEdge, const KeyEdgeList & newEdges)
 {
     QList<KeyHalfedge> newHalfedges;
 
-    foreach(KeyHalfedge he, halfedges_)
+    for(KeyHalfedge he: halfedges_)
     {
         if(he.edge == oldEdge)
         {

--- a/src/VAC/VectorAnimationComplex/SmartKeyEdgeSet.cpp
+++ b/src/VAC/VectorAnimationComplex/SmartKeyEdgeSet.cpp
@@ -122,7 +122,7 @@ SmartKeyEdgeSet::SmartKeyEdgeSet(const KeyEdgeSet & edgeSetConst) :
     // ===== First, each closed edge is its own connected component =====
 
     KeyEdgeSet remainingEdgesCopy = remainingEdges;
-    foreach(KeyEdge * iedge, remainingEdgesCopy)
+    for(KeyEdge * iedge: remainingEdgesCopy)
     {
         if(iedge->isClosed())
         {
@@ -172,7 +172,7 @@ SmartKeyEdgeSet::SmartKeyEdgeSet(const KeyEdgeSet & edgeSetConst) :
     QSet<SubVertex*> subVertices;
     QMap<Vertex*, SubVertex*> vertexToSubVertex;
     QMap<Edge*, SubEdge*> edgeToSubEdge;
-    foreach(Edge * edge, remainingEdges)
+    for(Edge * edge: remainingEdges)
     {
         // create new subcomplex edge
         SubEdge * subEdge = new SubEdge(edge);
@@ -236,9 +236,9 @@ SmartKeyEdgeSet::SmartKeyEdgeSet(const KeyEdgeSet & edgeSetConst) :
                 subEdge->marked = true;
 
                 // Insert neighbours in stack
-                foreach(SubEdge * neighbour, subEdge->leftSubVertex->subEdges)
+                for(SubEdge * neighbour: subEdge->leftSubVertex->subEdges)
                     toProcess.push(neighbour);
-                foreach(SubEdge * neighbour, subEdge->rightSubVertex->subEdges)
+                for(SubEdge * neighbour: subEdge->rightSubVertex->subEdges)
                     toProcess.push(neighbour);
             }
         }
@@ -251,9 +251,9 @@ SmartKeyEdgeSet::SmartKeyEdgeSet(const KeyEdgeSet & edgeSetConst) :
     // ===== Release memory =====
 
     // release memory
-    foreach(SubEdge * subEdge, subEdges)
+    for(SubEdge * subEdge: subEdges)
         delete subEdge;
-    foreach(SubVertex * subVertex, subVertices)
+    for(SubVertex * subVertex: subVertices)
         delete subVertex;
 }
 

--- a/src/VAC/VectorAnimationComplex/SmartKeyEdgeSet.cpp
+++ b/src/VAC/VectorAnimationComplex/SmartKeyEdgeSet.cpp
@@ -172,7 +172,7 @@ SmartKeyEdgeSet::SmartKeyEdgeSet(const KeyEdgeSet & edgeSetConst) :
     QSet<SubVertex*> subVertices;
     QMap<Vertex*, SubVertex*> vertexToSubVertex;
     QMap<Edge*, SubEdge*> edgeToSubEdge;
-    for(Edge * edge: remainingEdges)
+    for(Edge * edge: qAsConst(remainingEdges))
     {
         // create new subcomplex edge
         SubEdge * subEdge = new SubEdge(edge);
@@ -236,9 +236,9 @@ SmartKeyEdgeSet::SmartKeyEdgeSet(const KeyEdgeSet & edgeSetConst) :
                 subEdge->marked = true;
 
                 // Insert neighbours in stack
-                for(SubEdge * neighbour: subEdge->leftSubVertex->subEdges)
+                for(SubEdge * neighbour: qAsConst(subEdge->leftSubVertex->subEdges))
                     toProcess.push(neighbour);
-                for(SubEdge * neighbour: subEdge->rightSubVertex->subEdges)
+                for(SubEdge * neighbour: qAsConst(subEdge->rightSubVertex->subEdges))
                     toProcess.push(neighbour);
             }
         }
@@ -251,9 +251,9 @@ SmartKeyEdgeSet::SmartKeyEdgeSet(const KeyEdgeSet & edgeSetConst) :
     // ===== Release memory =====
 
     // release memory
-    for(SubEdge * subEdge: subEdges)
+    for(SubEdge * subEdge: qAsConst(subEdges))
         delete subEdge;
-    for(SubVertex * subVertex: subVertices)
+    for(SubVertex * subVertex: qAsConst(subVertices))
         delete subVertex;
 }
 

--- a/src/VAC/VectorAnimationComplex/TransformTool.cpp
+++ b/src/VAC/VectorAnimationComplex/TransformTool.cpp
@@ -856,7 +856,7 @@ void TransformTool::beginTransform(double x0, double y0, Time time)
         // Keyframe inbetween cells
         CellSet cellsNotToKeyframe;
         CellSet cellsToKeyframe;
-        foreach(Cell * c, cells_)
+        for(Cell * c: cells_)
         {
             InbetweenCell * sc = c->toInbetweenCell();
             if(sc)
@@ -883,7 +883,7 @@ void TransformTool::beginTransform(double x0, double y0, Time time)
 
         // Determine which cells to transform
         CellSet cellsToTransform = cellsNotToKeyframe;
-        foreach(KeyCell * c, keyframedCells)
+        for(KeyCell * c: keyframedCells)
             cellsToTransform << c;
         cellsToTransform = Algorithms::closure(cellsToTransform);
 
@@ -893,9 +893,9 @@ void TransformTool::beginTransform(double x0, double y0, Time time)
         draggedEdges_ = KeyEdgeSet(cellsToTransform);
 
         // prepare for affine transform
-        foreach(KeyEdge * e, draggedEdges_)
+        for(KeyEdge * e: draggedEdges_)
             e->prepareAffineTransform();
-        foreach(KeyVertex * v, draggedVertices_)
+        for(KeyVertex * v: draggedVertices_)
             v->prepareAffineTransform();
 
         // Cache initial mouse position
@@ -1052,13 +1052,13 @@ void TransformTool::continueTransform(double x, double y)
         xf = pivot * xf * pivot.inverse();
 
         // Apply affine transformation
-        foreach(KeyEdge * e, draggedEdges_)
+        for(KeyEdge * e: draggedEdges_)
             e->performAffineTransform(xf);
 
-        foreach(KeyVertex * v, draggedVertices_)
+        for(KeyVertex * v: draggedVertices_)
             v->performAffineTransform(xf);
 
-        foreach(KeyVertex * v, draggedVertices_)
+        for(KeyVertex * v: draggedVertices_)
             v->correctEdgesGeometry();
 
         // Apply transformation to manual pivot point

--- a/src/VAC/VectorAnimationComplex/TransformTool.cpp
+++ b/src/VAC/VectorAnimationComplex/TransformTool.cpp
@@ -856,7 +856,7 @@ void TransformTool::beginTransform(double x0, double y0, Time time)
         // Keyframe inbetween cells
         CellSet cellsNotToKeyframe;
         CellSet cellsToKeyframe;
-        for(Cell * c: cells_)
+        for(Cell * c: qAsConst(cells_))
         {
             InbetweenCell * sc = c->toInbetweenCell();
             if(sc)
@@ -893,9 +893,9 @@ void TransformTool::beginTransform(double x0, double y0, Time time)
         draggedEdges_ = KeyEdgeSet(cellsToTransform);
 
         // prepare for affine transform
-        for(KeyEdge * e: draggedEdges_)
+        for(KeyEdge * e: qAsConst(draggedEdges_))
             e->prepareAffineTransform();
-        for(KeyVertex * v: draggedVertices_)
+        for(KeyVertex * v: qAsConst(draggedVertices_))
             v->prepareAffineTransform();
 
         // Cache initial mouse position
@@ -1052,13 +1052,13 @@ void TransformTool::continueTransform(double x, double y)
         xf = pivot * xf * pivot.inverse();
 
         // Apply affine transformation
-        for(KeyEdge * e: draggedEdges_)
+        for(KeyEdge * e: qAsConst(draggedEdges_))
             e->performAffineTransform(xf);
 
-        for(KeyVertex * v: draggedVertices_)
+        for(KeyVertex * v: qAsConst(draggedVertices_))
             v->performAffineTransform(xf);
 
-        for(KeyVertex * v: draggedVertices_)
+        for(KeyVertex * v: qAsConst(draggedVertices_))
             v->correctEdgesGeometry();
 
         // Apply transformation to manual pivot point

--- a/src/VAC/VectorAnimationComplex/VAC.cpp
+++ b/src/VAC/VectorAnimationComplex/VAC.cpp
@@ -191,7 +191,7 @@ Cycle findClosestPlanarCycle(QSet<KeyEdge*> & potentialEdges,
             // If not found (maxIter reached or edge already rejected)
             if(!foundPotentialPlanarCycle)
             {
-                for(KeyHalfedge he: potentialPlanarCycle)
+                for(KeyHalfedge he: qAsConst(potentialPlanarCycle))
                 {
                     potentialEdges.remove(he.edge);
                 }
@@ -205,7 +205,7 @@ Cycle findClosestPlanarCycle(QSet<KeyEdge*> & potentialEdges,
                 }
                 else
                 {
-                    for(KeyHalfedge he: potentialPlanarCycle)
+                    for(KeyHalfedge he: qAsConst(potentialPlanarCycle))
                     {
                         potentialEdges.remove(he.edge);
                     }
@@ -315,14 +315,14 @@ VAC * VAC::clone()
     newVAC->ds_ = ds_;
 
     // Copy cells
-    for(Cell * cell: cells_)
+    for(Cell * cell: qAsConst(cells_))
     {
         Cell * newCell = cell->clone();
         newVAC->cells_[newCell->id()] = newCell;
         newCell->setSelected(false);
         newCell->setHovered(false);
     }
-    for(Cell * newCell: newVAC->cells_)
+    for(Cell * newCell: qAsConst(newVAC->cells_))
         newCell->remapPointers(newVAC);
     for(auto c: zOrdering_)
         newVAC->zOrdering_.insertLast(newVAC->getCell(c->id()));
@@ -347,7 +347,7 @@ QMap<int,int> VAC::import(VAC * other, bool selectImportedCells)
     }
 
     // Take ownership of all cells
-    for(Cell * c: ordering)
+    for(Cell * c: qAsConst(ordering))
     {
         int oldID = c->id();
         copyOfOther->removeCell_(c);
@@ -377,7 +377,7 @@ VAC * VAC::subcomplex(const CellSet & subcomplexCells)
     VAC * newVAC = clone();
 
     // Delete all cells but the one to keep
-    for (double id: idToDelete)
+    for (double id: qAsConst(idToDelete))
     {
         if(newVAC->cells_.contains(id))
             newVAC->deleteCell(newVAC->getCell(id));
@@ -933,11 +933,11 @@ void VAC::read(XmlStreamReader & xml)
 void VAC::read2ndPass_()
 {
     // Convert temp IDs (int) to pointers (Cell*)
-    for(Cell * cell: cells_)
+    for(Cell * cell: qAsConst(cells_))
         cell->read2ndPass();
 
     // Create star from boundary
-    for(Cell * cell: cells_)
+    for(Cell * cell: qAsConst(cells_))
     {
         CellSet spatialBoundary = cell->spatialBoundary();
         for(Cell * bcell: spatialBoundary)
@@ -953,7 +953,7 @@ void VAC::read2ndPass_()
     }
 
     // Clean geometry
-    for(Cell * cell: cells_)
+    for(Cell * cell: qAsConst(cells_))
     {
         KeyEdge * kedge = cell->toKeyEdge();
         if(kedge)
@@ -1073,7 +1073,7 @@ const ZOrderedCells & VAC::zOrdering() const
 CellSet VAC::cells()
 {
     CellSet res;
-    for(Cell * obj: cells_)
+    for(Cell * obj: qAsConst(cells_))
         res << obj;
     return res;
 }
@@ -1081,7 +1081,7 @@ CellSet VAC::cells()
 CellSet VAC::cells(Time time)
 {
     CellSet res;
-    for(Cell * c: cells_)
+    for(Cell * c: qAsConst(cells_))
     {
         if(c->exists(time))
             res << c;
@@ -1092,7 +1092,7 @@ CellSet VAC::cells(Time time)
 VertexCellList VAC::vertices()
 {
     VertexCellList res;
-    for(Cell * o: cells_)
+    for(Cell * o: qAsConst(cells_))
     {
         VertexCell *node = o->toVertexCell();
         if(node)
@@ -1103,7 +1103,7 @@ VertexCellList VAC::vertices()
 KeyVertexList VAC::instantVertices()
 {
     KeyVertexList res;
-    for(Cell * o: cells_)
+    for(Cell * o: qAsConst(cells_))
     {
         KeyVertex *node = o->toKeyVertex();
         if(node)
@@ -1115,7 +1115,7 @@ KeyVertexList VAC::instantVertices()
 EdgeCellList VAC::edges()
 {
     EdgeCellList res;
-    for(Cell * o: cells_)
+    for(Cell * o: qAsConst(cells_))
     {
         EdgeCell *edge = o->toEdgeCell();
         if(edge)
@@ -1127,7 +1127,7 @@ EdgeCellList VAC::edges()
 EdgeCellList VAC::edges(Time time)
 {
     EdgeCellList res;
-    for(Cell * o: cells_)
+    for(Cell * o: qAsConst(cells_))
     {
         EdgeCell *edge = o->toEdgeCell();
         if(edge && edge->exists(time))
@@ -1139,7 +1139,7 @@ EdgeCellList VAC::edges(Time time)
 FaceCellList VAC::faces()
 {
     FaceCellList res;
-    for(Cell * o: cells_)
+    for(Cell * o: qAsConst(cells_))
     {
         FaceCell *face = o->toFaceCell();
         if(face)
@@ -1152,7 +1152,7 @@ FaceCellList VAC::faces()
 KeyEdgeList VAC::instantEdges()
 {
     KeyEdgeList res;
-    for(Cell * o: cells_)
+    for(Cell * o: qAsConst(cells_))
     {
         KeyEdge * iedge = o->toKeyEdge();
         if(iedge)
@@ -1164,7 +1164,7 @@ KeyEdgeList VAC::instantEdges()
 KeyVertexList VAC::instantVertices(Time time)
 {
     KeyVertexList res;
-    for(Cell * o: cells_)
+    for(Cell * o: qAsConst(cells_))
     {
         KeyVertex *node = o->toKeyVertex();
         if(node && node->exists(time))
@@ -1176,7 +1176,7 @@ KeyVertexList VAC::instantVertices(Time time)
 KeyEdgeList VAC::instantEdges(Time time)
 {
     KeyEdgeList res;
-    for(Cell * o: cells_)
+    for(Cell * o: qAsConst(cells_))
     {
         KeyEdge * iedge = o->toKeyEdge();
         if(iedge && iedge->exists(time))
@@ -1294,7 +1294,8 @@ void VAC::smartDelete()
     // naive method for now, not efficient but works
     if(global()->deleteIsolatedVertices())
     {
-        for(KeyVertex * keyVertex: instantVertices())
+        const auto& instantKeyVertices = instantVertices();
+        for(KeyVertex * keyVertex: instantKeyVertices)
         {
             if(keyVertex->star().isEmpty())
                 deleteCell(keyVertex);
@@ -1321,7 +1322,8 @@ void VAC::deleteSelectedCells()
     // naive method for now, not efficient but works
     if(global()->deleteIsolatedVertices())
     {
-        for(KeyVertex * keyVertex: instantVertices())
+        const auto& instantKeyVertices = instantVertices();
+        for(KeyVertex * keyVertex: instantKeyVertices)
         {
             if(keyVertex->star().isEmpty())
                 deleteCell(keyVertex);
@@ -1362,7 +1364,7 @@ void VAC::deleteCell(Cell * cell)
     cell->destroyStar();
 
     // Inform observers of the upcoming deletion
-    for(CellObserver * observer: cell->observers_)
+    for(CellObserver * observer: qAsConst(cell->observers_))
         observer->observedCellDeleted(cell);
 
     // Remove the cell from the star of its boundary
@@ -3066,7 +3068,8 @@ bool VAC::uncut_(KeyEdge * e)
             // update f1
             f1->cycles_ = newCycles;
             f1->removeMeFromSpatialStarOf_(e);
-            for(Cell * c: f1->spatialBoundary())
+            const auto& spatialBoundaryObjects = f1->spatialBoundary();
+            for(Cell * c: spatialBoundaryObjects)
                 f1->addMeToSpatialStarOf_(c);
 
             // Recompute geometry
@@ -3349,7 +3352,8 @@ bool VAC::uncut_(KeyEdge * e)
         KeyFace * f = *incidentFaces.begin();
         f->cycles_ = newCycles;
         f->removeMeFromSpatialStarOf_(e);
-        for(Cell * c: f->spatialBoundary())
+        const auto& spatialBoundaryObjects = f->spatialBoundary();
+        for(Cell * c: spatialBoundaryObjects)
             f->addMeToSpatialStarOf_(c);
 
         // update z-ordering
@@ -3407,13 +3411,14 @@ void VAC::insertSketchedEdgeInVAC(double tolerance, bool useFaceToConsiderForCut
     if(intersectWithOthers)
     {
         InbetweenEdgeSet inbetweenEdges;
-        for(Cell * cell: cells())
+        const auto& animationComplexCells = cells();
+        for(Cell * cell: animationComplexCells)
         {
             InbetweenEdge * sedge = cell->toInbetweenEdge();
             if(sedge && sedge->exists(timeInteractivity_))
                 inbetweenEdges << sedge;
         }
-        for(InbetweenEdge * sedge: inbetweenEdges)
+        for(InbetweenEdge * sedge: qAsConst(inbetweenEdges))
         {
             // Get sampling as a QList of EdgeSamples
             QList<EdgeSample> sampling = sedge->getSampling(timeInteractivity_);
@@ -3446,7 +3451,7 @@ void VAC::insertSketchedEdgeInVAC(double tolerance, bool useFaceToConsiderForCut
         nEdges = iedgesBefore.size();
 
         // For each of them, compute intersections with sketched edge
-        for (KeyEdge * iedge: iedgesBefore)
+        for (KeyEdge * iedge: qAsConst(iedgesBefore))
         {
             // Convert geometry of instant edge to a SketchedEdge
             EdgeGeometry * geometry = iedge->geometry();
@@ -3557,7 +3562,7 @@ void VAC::insertSketchedEdgeInVAC(double tolerance, bool useFaceToConsiderForCut
     // For each of them, compute intersections with sketched edge
     {
         int i = 0;
-        for (KeyEdge * iedge: iedgesBefore)
+        for (KeyEdge * iedge: qAsConst(iedgesBefore))
         {
             // Avoid cleaning non-intersected existing edges
             if(othersSplitValues_dirty[i].size() > 0)
@@ -3701,7 +3706,7 @@ void VAC::insertSketchedEdgeInVAC(double tolerance, bool useFaceToConsiderForCut
     // Existing nodes, at the end of intersected other curves
     { // create scope so that i stays local
         int i=0;
-        for(KeyEdge * iedge: iedgesBefore) // TODO: generalize to Animated Nodes as well
+        for(KeyEdge * iedge: qAsConst(iedgesBefore)) // TODO: generalize to Animated Nodes as well
         {
             if(othersSplitValues[i].size() > 0 && !iedge->isClosed())
             {
@@ -3720,7 +3725,8 @@ void VAC::insertSketchedEdgeInVAC(double tolerance, bool useFaceToConsiderForCut
     {
         EdgeSample startVertex = sketchedEdge_->curve().start();
         EdgeSample endVertex = sketchedEdge_->curve().end();
-        for(KeyVertex * v: instantVertices(timeInteractivity_))
+        const auto& timeInteractivityVertices = instantVertices(timeInteractivity_);
+        for(KeyVertex * v: timeInteractivityVertices)
         {
             // todo: be careful!! Potentially add several times the same node here!!!
             EdgeSample sv = startVertex;
@@ -3750,7 +3756,7 @@ void VAC::insertSketchedEdgeInVAC(double tolerance, bool useFaceToConsiderForCut
     // them form
     {
         int i = 0;
-        for(KeyEdge * oldEdge: iedgesBefore)
+        for(KeyEdge * oldEdge: qAsConst(iedgesBefore))
         {
             if(othersSplitValues[i].size() > 2 || (oldEdge->isClosed() && othersSplitValues[i].size() > 1))
                 // avoid splitting if the cleaned split values are [0,l]
@@ -3758,7 +3764,7 @@ void VAC::insertSketchedEdgeInVAC(double tolerance, bool useFaceToConsiderForCut
             {
                 // Split the edge
                 SplitInfo info = cutEdgeAtVertices_(oldEdge, othersSplitValues[i]);
-                for(KeyVertex * ivertex: info.newVertices)
+                for(KeyVertex * ivertex: qAsConst(info.newVertices))
                 {
                     splitNodes.existing << EdgeSample(ivertex->pos()[0], ivertex->pos()[1]);
                     splitNodes.existingNodes << ivertex;
@@ -4104,9 +4110,9 @@ void VAC::insertSketchedEdgeInVAC(double tolerance, bool useFaceToConsiderForCut
                     cutFace_(face,iedge, &feedback);
                     if(useFaceToConsiderForCutting)
                     {
-                        for(KeyFace * face: feedback.deletedFaces)
+                        for(KeyFace * face: qAsConst(feedback.deletedFaces))
                             facesToConsiderForCutting_.remove(face);
-                        for(KeyFace * face: feedback.newFaces)
+                        for(KeyFace * face: qAsConst(feedback.newFaces))
                             facesToConsiderForCutting_.insert(face);
                     }
                 }
@@ -4365,7 +4371,7 @@ void VAC::inbetweenSelection()
     Time t1 = list[0]->time();
     Time t2;
     bool ok = false;
-    for(KeyCell * object: list)
+    for(KeyCell * object: qAsConst(list))
     {
         if(!ok) // didn't find t2 yet
         {
@@ -4397,7 +4403,7 @@ void VAC::inbetweenSelection()
     }
     KeyCellList list1;
     KeyCellList list2;
-    for(KeyCell * object: list)
+    for(KeyCell * object: qAsConst(list))
     {
         if(object->time() == t1)
             list1 << object;
@@ -4965,30 +4971,45 @@ KeyFace * VAC::keyframe_(InbetweenFace * sface, Time time)
 
         // Compute all nodes to delete
         QSet<AnimatedCycleNode*> beforeCycleNodesToDelete;
-        for(AnimatedCycleNode * node: beforeCycle.nodes())
+        std::for_each(std::begin(beforeCycle.nodes())
+                      , std::end(beforeCycle.nodes())
+                      , [&](AnimatedCycleNode * node)
+        {
             if(!node->cell()->isBefore(time))
                 beforeCycleNodesToDelete << node;
+        });
         QSet<AnimatedCycleNode*> afterCycleNodesToDelete;
-        for(AnimatedCycleNode * node: afterCycle.nodes())
+
+        std::for_each(std::begin(afterCycle.nodes())
+                      , std::end(afterCycle.nodes())
+                      , [&](AnimatedCycleNode * node)
+        {
             if(!node->cell()->isAfter(time))
                 afterCycleNodesToDelete << node;
-
+        });
         // Set pointers to deleted nodes to null instead
-        for(AnimatedCycleNode * node: beforeCycle.nodes())
+        std::for_each(std::begin(beforeCycle.nodes())
+                      , std::end(beforeCycle.nodes())
+                      , [&](AnimatedCycleNode * node)
+        {
             if(beforeCycleNodesToDelete.contains(node->after()))
                 node->setAfter(0);
-        for(AnimatedCycleNode * node: afterCycle.nodes())
+        });
+        std::for_each(std::begin(afterCycle.nodes())
+                      , std::end(afterCycle.nodes())
+                      , [&](AnimatedCycleNode * node)
+        {
             if(afterCycleNodesToDelete.contains(node->before()))
                 node->setBefore(0);
-
+        });
         // Set "first"
         beforeCycle.setFirst(beforeCycleFirst);
         afterCycle.setFirst(afterCycleFirst);
 
         // Delete nodes to delete
-        for(AnimatedCycleNode * node: beforeCycleNodesToDelete)
+        for(AnimatedCycleNode * node: qAsConst(beforeCycleNodesToDelete))
             delete node;
-        for(AnimatedCycleNode * node: afterCycleNodesToDelete)
+        for(AnimatedCycleNode * node: qAsConst(afterCycleNodesToDelete))
             delete node;
 
         // Add cycles to new inbetween faces
@@ -5288,7 +5309,8 @@ void VAC::removeCyclesFromFace()
         for(int i=0; i<face->cycles_.size(); ++i)
         {
             bool keepCycle = true;
-            for(KeyCell * cell: face->cycles_[i].cells())
+            const auto& faceCycleCells = face->cycles_[i].cells();
+            for(KeyCell * cell: faceCycleCells)
             {
                 if(cell->isSelected())
                 {
@@ -5820,7 +5842,7 @@ void VAC::informTimelineOfSelection()
     double t1 = 0;
     double t2 = 0;
 
-    for(Cell * cell: selectedCells_)
+    for(Cell * cell: qAsConst(selectedCells_))
     {
         KeyCell * keyCell = cell->toKeyCell();
         InbetweenCell * inbetweenCell = cell->toInbetweenCell();
@@ -5983,7 +6005,7 @@ void VAC::setSelectedCells(const CellSet & cells, bool emitSignal)
     // all old cells as unselected.
     // This works due to the previous step: any cell in selectedCells_
     // which is still selected is *not* in the new cells.
-    for(Cell * cell: selectedCells_)
+    for(Cell * cell: qAsConst(selectedCells_))
     {
         if (cell->isSelected())
         {
@@ -6273,7 +6295,7 @@ void VAC::prepareDragAndDrop(double x0, double y0, Time time)
     // Partition into three sets of cells
     CellSet cellsNotToKeyframe;
     CellSet cellsToKeyframe;
-    for(Cell * c: cellsToDrag)
+    for(Cell * c: qAsConst(cellsToDrag))
     {
         InbetweenCell * sc = c->toInbetweenCell();
         if(sc)
@@ -6307,9 +6329,9 @@ void VAC::prepareDragAndDrop(double x0, double y0, Time time)
     draggedEdges_ = KeyEdgeSet(cellsToDrag);
 
     // prepare drag and drop
-    for(KeyEdge * iedge: draggedEdges_)
+    for(KeyEdge * iedge: qAsConst(draggedEdges_))
         iedge->geometry()->prepareDragAndDrop();
-    for(KeyVertex * v: draggedVertices_)
+    for(KeyVertex * v: qAsConst(draggedVertices_))
         v->prepareDragAndDrop();
 
     x0_ = x0;
@@ -6337,17 +6359,17 @@ void VAC::performDragAndDrop(double x, double y)
         else if (std::abs(theta + 3*PI/4) <   PI/8) { dx = -d; dy = -d; }
     }
 
-    for(KeyEdge * iedge: draggedEdges_)
+    for(KeyEdge * iedge: qAsConst(draggedEdges_))
     {
         iedge->geometry()->performDragAndDrop(dx, dy);
         iedge->processGeometryChanged_();
     }
 
-    for(KeyVertex * v: draggedVertices_)
+    for(KeyVertex * v: qAsConst(draggedVertices_))
         v->performDragAndDrop(dx, dy);
 
 
-    for(KeyVertex * v: draggedVertices_)
+    for(KeyVertex * v: qAsConst(draggedVertices_))
         v->correctEdgesGeometry();
 
     transformTool_.performDragAndDrop(dx, dy);
@@ -6390,7 +6412,7 @@ void VAC::prepareTemporalDragAndDrop(Time t0)
     deltaTMin_ = Time(-1000);
     deltaTMax_ = Time(1000);
 
-    for(KeyCell * keyCell: draggedKeyCells_)
+    for(KeyCell * keyCell: qAsConst(draggedKeyCells_))
     {
         Time deltaTMin = keyCell->temporalDragMinTime() - keyCell->time();
         if(deltaTMin_ < deltaTMin)
@@ -6412,7 +6434,7 @@ void VAC::performTemporalDragAndDrop(Time t)
     if(deltaTime >= deltaTMax_)
         return;
 
-    for(KeyCell * keyCell: draggedKeyCells_)
+    for(KeyCell * keyCell: qAsConst(draggedKeyCells_))
         keyCell->setTime(draggedKeyCellTime_[keyCell] + deltaTime);
 
     emit changed();
@@ -6591,20 +6613,26 @@ void VAC::updateToBePaintedFace(double x, double y, Time time)
 
     // Compute distances to all edges
     QMap<KeyEdge*,EdgeGeometry::ClosestVertexInfo> distancesToEdges;
-    for(KeyEdge * e: instantEdges())
-        distancesToEdges[e] = e->geometry()->closestPoint(x,y);
 
+    std::for_each(std::begin(instantEdges())
+                  , std::end(instantEdges())
+                  , [&](KeyEdge * e)
+    {
+        distancesToEdges[e] = e->geometry()->closestPoint(x,y);
+    });
     // First, we try to create such a face assuming that the
     // VGC is actually planar (cells are not overlapping).
     bool foundPlanarFace = false;
     {
         // Find external boundary: the closest planar cycle containing mouse cursor
         QSet<KeyEdge*> potentialExternalBoundaryEdges;
-        for(KeyEdge* e: instantEdges())
+        std::for_each(std::begin(instantEdges())
+                      , std::end(instantEdges())
+                      , [&](KeyEdge * e)
         {
             if(e->exists(time))
                 potentialExternalBoundaryEdges.insert(e);
-        }
+        });
         PreviewKeyFace externalBoundary;
         bool foundExternalBoundary = false;
         while(!(foundExternalBoundary || potentialExternalBoundaryEdges.isEmpty()))
@@ -6691,7 +6719,7 @@ void VAC::updateToBePaintedFace(double x, double y, Time time)
                 // If not found (maxIter reached or edge already rejected)
                 if(!foundPotentialPlanarCycle)
                 {
-                    for(KeyHalfedge he: potentialPlanarCycle)
+                    for(KeyHalfedge he: qAsConst(potentialPlanarCycle))
                     {
                         potentialExternalBoundaryEdges.remove(he.edge);
                     }
@@ -6708,7 +6736,7 @@ void VAC::updateToBePaintedFace(double x, double y, Time time)
                         }
                         else
                         {
-                            for(KeyHalfedge he: potentialPlanarCycle)
+                            for(KeyHalfedge he: qAsConst(potentialPlanarCycle))
                             {
                                 potentialExternalBoundaryEdges.remove(he.edge);
                             }
@@ -6717,7 +6745,7 @@ void VAC::updateToBePaintedFace(double x, double y, Time time)
                     }
                     else
                     {
-                        for(KeyHalfedge he: potentialPlanarCycle)
+                        for(KeyHalfedge he: qAsConst(potentialPlanarCycle))
                         {
                             potentialExternalBoundaryEdges.remove(he.edge);
                         }
@@ -6737,11 +6765,13 @@ void VAC::updateToBePaintedFace(double x, double y, Time time)
 
             // Now, let's try to add holes to the external boundary
             QSet<KeyEdge*> potentialHoleEdges;
-            for(KeyEdge* e: instantEdges())
+            std::for_each(std::begin(instantEdges())
+                          , std::end(instantEdges())
+                          , [&](KeyEdge * e)
             {
                 if(e->exists(time))
                     potentialHoleEdges.insert(e);
-            }
+            });
             CellSet cellsInExternalBoundary = externalBoundary.cycles()[0].cells();
             KeyEdgeSet edgesInExternalBoundary = cellsInExternalBoundary;
             for(KeyEdge * e: edgesInExternalBoundary)

--- a/src/VAC/VectorAnimationComplex/VAC.cpp
+++ b/src/VAC/VectorAnimationComplex/VAC.cpp
@@ -79,7 +79,7 @@ bool isCycleContainedInFace(const Cycle & cycle, const PreviewKeyFace & face)
 
     // Compute total length of edges
     double totalLength = 0;
-    foreach (KeyEdge * edge, cycleEdges)
+    for (KeyEdge * edge: cycleEdges)
         totalLength += edge->geometry()->length();
 
     // Compute percentage of edges inside face, based on approximately N samples
@@ -87,7 +87,7 @@ bool isCycleContainedInFace(const Cycle & cycle, const PreviewKeyFace & face)
     double ds = totalLength / N;
     double nInside = 0;
     double nOutside = 0;
-    foreach (KeyEdge * edge, cycleEdges)
+    for (KeyEdge * edge: cycleEdges)
     {
         EdgeGeometry * geometry = edge->geometry();
         double L = geometry->length();
@@ -121,7 +121,7 @@ Cycle findClosestPlanarCycle(QSet<KeyEdge*> & potentialEdges,
         EdgeGeometry::ClosestVertexInfo cvi;
         cvi.s = 0;
         cvi.d = std::numeric_limits<double>::max();
-        foreach(KeyEdge * e, potentialEdges)
+        for(KeyEdge * e: potentialEdges)
         {
             EdgeGeometry::ClosestVertexInfo cvi_e = distancesToEdges[e];
             if(cvi_e.d < cvi.d)
@@ -191,7 +191,7 @@ Cycle findClosestPlanarCycle(QSet<KeyEdge*> & potentialEdges,
             // If not found (maxIter reached or edge already rejected)
             if(!foundPotentialPlanarCycle)
             {
-                foreach(KeyHalfedge he, potentialPlanarCycle)
+                for(KeyHalfedge he: potentialPlanarCycle)
                 {
                     potentialEdges.remove(he.edge);
                 }
@@ -205,7 +205,7 @@ Cycle findClosestPlanarCycle(QSet<KeyEdge*> & potentialEdges,
                 }
                 else
                 {
-                    foreach(KeyHalfedge he, potentialPlanarCycle)
+                    for(KeyHalfedge he: potentialPlanarCycle)
                     {
                         potentialEdges.remove(he.edge);
                     }
@@ -315,14 +315,14 @@ VAC * VAC::clone()
     newVAC->ds_ = ds_;
 
     // Copy cells
-    foreach(Cell * cell, cells_)
+    for(Cell * cell: cells_)
     {
         Cell * newCell = cell->clone();
         newVAC->cells_[newCell->id()] = newCell;
         newCell->setSelected(false);
         newCell->setHovered(false);
     }
-    foreach(Cell * newCell, newVAC->cells_)
+    for(Cell * newCell: newVAC->cells_)
         newCell->remapPointers(newVAC);
     for(auto c: zOrdering_)
         newVAC->zOrdering_.insertLast(newVAC->getCell(c->id()));
@@ -347,7 +347,7 @@ QMap<int,int> VAC::import(VAC * other, bool selectImportedCells)
     }
 
     // Take ownership of all cells
-    foreach(Cell * c, ordering)
+    for(Cell * c: ordering)
     {
         int oldID = c->id();
         copyOfOther->removeCell_(c);
@@ -370,14 +370,14 @@ VAC * VAC::subcomplex(const CellSet & subcomplexCells)
     CellSet cellsToDelete = cells();
     cellsToDelete.subtract(cellsToKeep);
     QList<int> idToDelete;
-    foreach(Cell * c, cellsToDelete)
+    for(Cell * c: cellsToDelete)
         idToDelete << c->id();
 
     // Create new Graph
     VAC * newVAC = clone();
 
     // Delete all cells but the one to keep
-    foreach (double id, idToDelete)
+    for (double id: idToDelete)
     {
         if(newVAC->cells_.contains(id))
             newVAC->deleteCell(newVAC->getCell(id));
@@ -692,7 +692,7 @@ void VAC::draw(Time time, ViewSettings & viewSettings)
     if(DevSettings::getBool("draw edge orientation"))
     {
         KeyEdgeSet edges = cells();
-        foreach(KeyEdge * e, edges)
+        for(KeyEdge * e: edges)
         {
             if(e->exists(time))
             {
@@ -703,7 +703,7 @@ void VAC::draw(Time time, ViewSettings & viewSettings)
             }
         }
         InbetweenEdgeSet sedges = cells();
-        foreach(InbetweenEdge * se, sedges)
+        for(InbetweenEdge * se: sedges)
         {
             if(se->exists(time))
             {
@@ -840,7 +840,7 @@ void VAC::toggle(Time /*time*/, int id)
 void VAC::deselectAll(Time time)
 {
     CellSet cellsToDeselect;
-    foreach(Cell * cell, selectedCells())
+    for(Cell * cell: selectedCells())
         if(cell->exists(time))
             cellsToDeselect << cell;
     removeFromSelection(cellsToDeselect,false);
@@ -933,27 +933,27 @@ void VAC::read(XmlStreamReader & xml)
 void VAC::read2ndPass_()
 {
     // Convert temp IDs (int) to pointers (Cell*)
-    foreach(Cell * cell, cells_)
+    for(Cell * cell: cells_)
         cell->read2ndPass();
 
     // Create star from boundary
-    foreach(Cell * cell, cells_)
+    for(Cell * cell: cells_)
     {
         CellSet spatialBoundary = cell->spatialBoundary();
-        foreach(Cell * bcell, spatialBoundary)
+        for(Cell * bcell: spatialBoundary)
             cell->addMeToSpatialStarOf_(bcell);
 
         CellSet temporalBoundaryBefore = cell->beforeCells();
-        foreach(Cell * bcell, temporalBoundaryBefore)
+        for(Cell * bcell: temporalBoundaryBefore)
             cell->addMeToTemporalStarAfterOf_(bcell);
 
         CellSet temporalBoundaryAfter = cell->afterCells();
-        foreach(Cell * bcell, temporalBoundaryAfter)
+        for(Cell * bcell: temporalBoundaryAfter)
             cell->addMeToTemporalStarBeforeOf_(bcell);
     }
 
     // Clean geometry
-    foreach(Cell * cell, cells_)
+    for(Cell * cell: cells_)
     {
         KeyEdge * kedge = cell->toKeyEdge();
         if(kedge)
@@ -1073,7 +1073,7 @@ const ZOrderedCells & VAC::zOrdering() const
 CellSet VAC::cells()
 {
     CellSet res;
-    foreach(Cell * obj, cells_)
+    for(Cell * obj: cells_)
         res << obj;
     return res;
 }
@@ -1081,7 +1081,7 @@ CellSet VAC::cells()
 CellSet VAC::cells(Time time)
 {
     CellSet res;
-    foreach(Cell * c, cells_)
+    for(Cell * c: cells_)
     {
         if(c->exists(time))
             res << c;
@@ -1092,7 +1092,7 @@ CellSet VAC::cells(Time time)
 VertexCellList VAC::vertices()
 {
     VertexCellList res;
-    foreach(Cell * o, cells_)
+    for(Cell * o: cells_)
     {
         VertexCell *node = o->toVertexCell();
         if(node)
@@ -1103,7 +1103,7 @@ VertexCellList VAC::vertices()
 KeyVertexList VAC::instantVertices()
 {
     KeyVertexList res;
-    foreach(Cell * o, cells_)
+    for(Cell * o: cells_)
     {
         KeyVertex *node = o->toKeyVertex();
         if(node)
@@ -1115,7 +1115,7 @@ KeyVertexList VAC::instantVertices()
 EdgeCellList VAC::edges()
 {
     EdgeCellList res;
-    foreach(Cell * o, cells_)
+    for(Cell * o: cells_)
     {
         EdgeCell *edge = o->toEdgeCell();
         if(edge)
@@ -1127,7 +1127,7 @@ EdgeCellList VAC::edges()
 EdgeCellList VAC::edges(Time time)
 {
     EdgeCellList res;
-    foreach(Cell * o, cells_)
+    for(Cell * o: cells_)
     {
         EdgeCell *edge = o->toEdgeCell();
         if(edge && edge->exists(time))
@@ -1139,7 +1139,7 @@ EdgeCellList VAC::edges(Time time)
 FaceCellList VAC::faces()
 {
     FaceCellList res;
-    foreach(Cell * o, cells_)
+    for(Cell * o: cells_)
     {
         FaceCell *face = o->toFaceCell();
         if(face)
@@ -1152,7 +1152,7 @@ FaceCellList VAC::faces()
 KeyEdgeList VAC::instantEdges()
 {
     KeyEdgeList res;
-    foreach(Cell * o, cells_)
+    for(Cell * o: cells_)
     {
         KeyEdge * iedge = o->toKeyEdge();
         if(iedge)
@@ -1164,7 +1164,7 @@ KeyEdgeList VAC::instantEdges()
 KeyVertexList VAC::instantVertices(Time time)
 {
     KeyVertexList res;
-    foreach(Cell * o, cells_)
+    for(Cell * o: cells_)
     {
         KeyVertex *node = o->toKeyVertex();
         if(node && node->exists(time))
@@ -1176,7 +1176,7 @@ KeyVertexList VAC::instantVertices(Time time)
 KeyEdgeList VAC::instantEdges(Time time)
 {
     KeyEdgeList res;
-    foreach(Cell * o, cells_)
+    for(Cell * o: cells_)
     {
         KeyEdge * iedge = o->toKeyEdge();
         if(iedge && iedge->exists(time))
@@ -1263,13 +1263,13 @@ void VAC::smartDelete_(const CellSet & cellsToDelete)
     KeyEdgeSet edgesToDelete= cellsToDelete;
     KeyVertexSet verticesToDelete = cellsToDelete;
 
-    foreach(KeyFace * iface, facesToDelete)
+    for(KeyFace * iface: facesToDelete)
         smartDeleteCell(iface);
 
-    foreach(KeyEdge * iedge, edgesToDelete)
+    for(KeyEdge * iedge: edgesToDelete)
         smartDeleteCell(iedge);
 
-    foreach(KeyVertex * ivertex, verticesToDelete)
+    for(KeyVertex * ivertex: verticesToDelete)
         smartDeleteCell(ivertex);
 }
 
@@ -1294,7 +1294,7 @@ void VAC::smartDelete()
     // naive method for now, not efficient but works
     if(global()->deleteIsolatedVertices())
     {
-        foreach(KeyVertex * keyVertex, instantVertices())
+        for(KeyVertex * keyVertex: instantVertices())
         {
             if(keyVertex->star().isEmpty())
                 deleteCell(keyVertex);
@@ -1321,7 +1321,7 @@ void VAC::deleteSelectedCells()
     // naive method for now, not efficient but works
     if(global()->deleteIsolatedVertices())
     {
-        foreach(KeyVertex * keyVertex, instantVertices())
+        for(KeyVertex * keyVertex: instantVertices())
         {
             if(keyVertex->star().isEmpty())
                 deleteCell(keyVertex);
@@ -1335,7 +1335,7 @@ void VAC::deleteSelectedCells()
 
 void VAC::deleteCells(const QSet<int>  & cellIds)
 {
-    foreach(int id, cellIds)
+    for(int id: cellIds)
     {
         // Get cell corresponding to ID
         Cell * cell = getCell(id);
@@ -1351,7 +1351,7 @@ void VAC::deleteCells(const QSet<int>  & cellIds)
 void VAC::deleteCells(const CellSet & cells)
 {
     QSet<int> cellIds;
-    foreach(Cell * c, cells)
+    for(Cell * c: cells)
         cellIds << c->id();
     deleteCells(cellIds);
 }
@@ -1362,7 +1362,7 @@ void VAC::deleteCell(Cell * cell)
     cell->destroyStar();
 
     // Inform observers of the upcoming deletion
-    foreach(CellObserver * observer, cell->observers_)
+    for(CellObserver * observer: cell->observers_)
         observer->observedCellDeleted(cell);
 
     // Remove the cell from the star of its boundary
@@ -1418,7 +1418,7 @@ void VAC::smartDeleteCell(Cell * cell)
         {
             // Great, this means starEdges is the direct star of cell
             // Atomic simplify all of them
-            foreach(KeyEdge * iedge, starEdges)
+            for(KeyEdge * iedge: starEdges)
             {
                 atomicSimplifyAtCell(iedge);
             }
@@ -1999,14 +1999,14 @@ bool VAC::cutFace_(KeyFace * face, KeyEdge * edge, CutFaceFeedback * feedback)
 
             // Update star
             InbetweenFaceSet sfacesbefore = face->temporalStarBefore();
-            foreach(InbetweenFace * sface, sfacesbefore)
+            for(InbetweenFace * sface: sfacesbefore)
             {
                 sface->removeAfterFace(face);
                 sface->addAfterFace(f1);
                 sface->addAfterFace(f2);
             }
             InbetweenFaceSet sfacesafter = face->temporalStarAfter();
-            foreach(InbetweenFace * sface, sfacesafter)
+            for(InbetweenFace * sface: sfacesafter)
             {
                 sface->removeBeforeFace(face);
                 sface->addBeforeFace(f1);
@@ -2194,22 +2194,22 @@ VAC::SplitInfo VAC::cutEdgeAtVertices_(KeyEdge * edgeToSplit, const std::vector<
     KeyFaceSet keyFaces =  star;
     InbetweenEdgeSet inbetweenEdges =  star;
     InbetweenFaceSet inbetweenFaces =  star;
-    foreach(KeyFace * c, keyFaces)
+    for(KeyFace * c: keyFaces)
     {
         c->updateBoundary(res.oldEdge, res.newEdges);
         c->processGeometryChanged_();
     }
-    foreach(InbetweenEdge * c, inbetweenEdges)
+    for(InbetweenEdge * c: inbetweenEdges)
     {
         c->updateBoundary(res.oldEdge, res.newEdges);
     }
-    foreach(InbetweenFace * c, inbetweenFaces)
+    for(InbetweenFace * c: inbetweenFaces)
     {
         c->updateBoundary(res.oldEdge, res.newEdges);
     }
 
     // Now that all calls of c->boundary() are trustable, update cached star
-    foreach(Cell * c, star)
+    for(Cell * c: star)
     {
         c->removeMeFromStarOf_(res.oldEdge);
         c->addMeToStarOfBoundary_();
@@ -2282,36 +2282,36 @@ void VAC::glue_(KeyVertex * v1, KeyVertex * v2)
     InbetweenVertexSet inbetweenVertices =  star;
     InbetweenEdgeSet inbetweenEdges =  star;
     InbetweenFaceSet inbetweenFaces =  star;
-    foreach(KeyEdge * c, keyEdges)
+    for(KeyEdge * c: keyEdges)
     {
         c->updateBoundary(v1,v3);
         c->updateBoundary(v2,v3);
         c->correctGeometry();
     }
-    foreach(InbetweenVertex * c, inbetweenVertices)
+    for(InbetweenVertex * c: inbetweenVertices)
     {
         c->updateBoundary(v1,v3);
         c->updateBoundary(v2,v3);
     }
-    foreach(KeyFace * c, keyFaces)
+    for(KeyFace * c: keyFaces)
     {
         c->updateBoundary(v1,v3);
         c->updateBoundary(v2,v3);
         c->processGeometryChanged_();
     }
-    foreach(InbetweenEdge * c, inbetweenEdges)
+    for(InbetweenEdge * c: inbetweenEdges)
     {
         c->updateBoundary(v1,v3);
         c->updateBoundary(v2,v3);
     }
-    foreach(InbetweenFace * c, inbetweenFaces)
+    for(InbetweenFace * c: inbetweenFaces)
     {
         c->updateBoundary(v1,v3);
         c->updateBoundary(v2,v3);
     }
 
     // Now that all calls of c->boundary() are trustable, update cached star
-    foreach(Cell * c, star)
+    for(Cell * c: star)
     {
         c->removeMeFromStarOf_(v1);
         c->removeMeFromStarOf_(v2);
@@ -2421,25 +2421,25 @@ void VAC::glue_(const KeyHalfedge &h1, const KeyHalfedge &h2)
     KeyFaceSet keyFaces =  star;
     InbetweenEdgeSet inbetweenEdges =  star;
     InbetweenFaceSet inbetweenFaces =  star;
-    foreach(KeyFace * c, keyFaces)
+    for(KeyFace * c: keyFaces)
     {
         c->updateBoundary(h1,h3);
         c->updateBoundary(h2,h3);
         c->processGeometryChanged_();
     }
-    foreach(InbetweenEdge * c, inbetweenEdges)
+    for(InbetweenEdge * c: inbetweenEdges)
     {
         c->updateBoundary(h1,h3);
         c->updateBoundary(h2,h3);
     }
-    foreach(InbetweenFace * c, inbetweenFaces)
+    for(InbetweenFace * c: inbetweenFaces)
     {
         c->updateBoundary(h1,h3);
         c->updateBoundary(h2,h3);
     }
 
     // Now that all calls of c->boundary() are trustable, update cached star
-    foreach(Cell * c, star)
+    for(Cell * c: star)
     {
         c->removeMeFromStarOf_(e1);
         c->removeMeFromStarOf_(e2);
@@ -2463,7 +2463,7 @@ int VAC::nUses_(KeyVertex * v)
     KeyFaceSet incidentFaces = v->spatialStar();
     KeyEdgeSet incidentEdges = v->spatialStar();
 
-    foreach(KeyFace * f, incidentFaces)
+    for(KeyFace * f: incidentFaces)
     {
         // count how many times f uses v
         for(int i=0; i<f->cycles_.size(); ++i)
@@ -2479,7 +2479,7 @@ int VAC::nUses_(KeyVertex * v)
         }
     }
 
-    foreach(KeyEdge * e, incidentEdges)
+    for(KeyEdge * e: incidentEdges)
     {
         KeyFaceSet fs = e->spatialStar();
         if(fs.size() == 0) // otherwise, will be counted as a use by the face
@@ -2499,7 +2499,7 @@ int VAC::nUses_(KeyEdge * e)
     int res = 0;
 
     KeyFaceSet incidentFaces = e->spatialStar();
-    foreach(KeyFace * f, incidentFaces)
+    for(KeyFace * f: incidentFaces)
     {
         // count how many times f uses e
         for(int i=0; i<f->cycles_.size(); ++i)
@@ -2531,14 +2531,14 @@ void VAC::unglue_(KeyVertex * v)
 
         // Unglue all incident edges
         KeyEdgeSet iEdges = v->spatialStar();
-        foreach(KeyEdge * edge, iEdges)
+        for(KeyEdge * edge: iEdges)
             unglue_(edge);
 
         // Creates one duplicate vertex for each use
         KeyFaceSet incidentFaces = v->spatialStar();
         KeyEdgeSet incidentEdges = v->spatialStar();
 
-        foreach(KeyFace * f, incidentFaces)
+        for(KeyFace * f: incidentFaces)
         {
             for(int i=0; i<f->cycles_.size(); ++i)
             {
@@ -2610,7 +2610,7 @@ void VAC::unglue_(KeyVertex * v)
             f->processGeometryChanged_();
         }
 
-        foreach(KeyEdge * e, incidentEdges)
+        for(KeyEdge * e: incidentEdges)
         {
             KeyFaceSet fs = e->spatialStar();
             if(fs.size() == 0) // otherwise, will be counted as a use by the face
@@ -2662,7 +2662,7 @@ void VAC::unglue_(KeyEdge * e)
 
         // Create one duplicate edge for each use
         KeyFaceSet incidentFaces = e->spatialStar();
-        foreach(KeyFace * f, incidentFaces)
+        for(KeyFace * f: incidentFaces)
         {
             for(int i=0; i<f->cycles_.size(); ++i)
             {
@@ -2722,7 +2722,7 @@ bool VAC::uncut_(KeyVertex * v)
         bool found = false;
         KeyFace * foundFace = 0;
         int foundI = -1;
-        foreach(KeyFace * f, incidentFaces)
+        for(KeyFace * f: incidentFaces)
         {
             for(int i=0; i<f->cycles_.size(); ++i)
             {
@@ -2802,7 +2802,7 @@ bool VAC::uncut_(KeyVertex * v)
 
     // check that removing this vertex is compatible with incident faces
     KeyFaceSet incidentFaces = v->spatialStar();
-    foreach(KeyFace * f, incidentFaces)
+    for(KeyFace * f: incidentFaces)
     {
         // check that it can be removed
         for(int i=0; i<f->cycles_.size(); ++i)
@@ -2864,7 +2864,7 @@ bool VAC::uncut_(KeyVertex * v)
         e1->geometry()->makeLoop();
 
         // update incident faces
-        foreach(KeyFace * f, incidentFaces)
+        for(KeyFace * f: incidentFaces)
         {
             for(int i=0; i<f->cycles_.size(); ++i)
             {
@@ -2930,7 +2930,7 @@ bool VAC::uncut_(KeyVertex * v)
         e->setColor(lerp(color1,color2,0.5));
 
         // update incident faces
-        foreach(KeyFace * f, incidentFaces)
+        for(KeyFace * f: incidentFaces)
         {
             for(int i=0; i<f->cycles_.size(); ++i)
             {
@@ -3066,7 +3066,7 @@ bool VAC::uncut_(KeyEdge * e)
             // update f1
             f1->cycles_ = newCycles;
             f1->removeMeFromSpatialStarOf_(e);
-            foreach(Cell * c, f1->spatialBoundary())
+            for(Cell * c: f1->spatialBoundary())
                 f1->addMeToSpatialStarOf_(c);
 
             // Recompute geometry
@@ -3349,7 +3349,7 @@ bool VAC::uncut_(KeyEdge * e)
         KeyFace * f = *incidentFaces.begin();
         f->cycles_ = newCycles;
         f->removeMeFromSpatialStarOf_(e);
-        foreach(Cell * c, f->spatialBoundary())
+        for(Cell * c: f->spatialBoundary())
             f->addMeToSpatialStarOf_(c);
 
         // update z-ordering
@@ -3407,13 +3407,13 @@ void VAC::insertSketchedEdgeInVAC(double tolerance, bool useFaceToConsiderForCut
     if(intersectWithOthers)
     {
         InbetweenEdgeSet inbetweenEdges;
-        foreach(Cell * cell, cells())
+        for(Cell * cell: cells())
         {
             InbetweenEdge * sedge = cell->toInbetweenEdge();
             if(sedge && sedge->exists(timeInteractivity_))
                 inbetweenEdges << sedge;
         }
-        foreach(InbetweenEdge * sedge, inbetweenEdges)
+        for(InbetweenEdge * sedge: inbetweenEdges)
         {
             // Get sampling as a QList of EdgeSamples
             QList<EdgeSample> sampling = sedge->getSampling(timeInteractivity_);
@@ -3446,7 +3446,7 @@ void VAC::insertSketchedEdgeInVAC(double tolerance, bool useFaceToConsiderForCut
         nEdges = iedgesBefore.size();
 
         // For each of them, compute intersections with sketched edge
-        foreach (KeyEdge * iedge, iedgesBefore)
+        for (KeyEdge * iedge: iedgesBefore)
         {
             // Convert geometry of instant edge to a SketchedEdge
             EdgeGeometry * geometry = iedge->geometry();
@@ -3557,7 +3557,7 @@ void VAC::insertSketchedEdgeInVAC(double tolerance, bool useFaceToConsiderForCut
     // For each of them, compute intersections with sketched edge
     {
         int i = 0;
-        foreach (KeyEdge * iedge, iedgesBefore)
+        for (KeyEdge * iedge: iedgesBefore)
         {
             // Avoid cleaning non-intersected existing edges
             if(othersSplitValues_dirty[i].size() > 0)
@@ -3701,7 +3701,7 @@ void VAC::insertSketchedEdgeInVAC(double tolerance, bool useFaceToConsiderForCut
     // Existing nodes, at the end of intersected other curves
     { // create scope so that i stays local
         int i=0;
-        foreach(KeyEdge * iedge, iedgesBefore) // TODO: generalize to Animated Nodes as well
+        for(KeyEdge * iedge: iedgesBefore) // TODO: generalize to Animated Nodes as well
         {
             if(othersSplitValues[i].size() > 0 && !iedge->isClosed())
             {
@@ -3720,7 +3720,7 @@ void VAC::insertSketchedEdgeInVAC(double tolerance, bool useFaceToConsiderForCut
     {
         EdgeSample startVertex = sketchedEdge_->curve().start();
         EdgeSample endVertex = sketchedEdge_->curve().end();
-        foreach(KeyVertex * v, instantVertices(timeInteractivity_))
+        for(KeyVertex * v: instantVertices(timeInteractivity_))
         {
             // todo: be careful!! Potentially add several times the same node here!!!
             EdgeSample sv = startVertex;
@@ -3750,7 +3750,7 @@ void VAC::insertSketchedEdgeInVAC(double tolerance, bool useFaceToConsiderForCut
     // them form
     {
         int i = 0;
-        foreach(KeyEdge * oldEdge, iedgesBefore)
+        for(KeyEdge * oldEdge: iedgesBefore)
         {
             if(othersSplitValues[i].size() > 2 || (oldEdge->isClosed() && othersSplitValues[i].size() > 1))
                 // avoid splitting if the cleaned split values are [0,l]
@@ -3758,7 +3758,7 @@ void VAC::insertSketchedEdgeInVAC(double tolerance, bool useFaceToConsiderForCut
             {
                 // Split the edge
                 SplitInfo info = cutEdgeAtVertices_(oldEdge, othersSplitValues[i]);
-                foreach(KeyVertex * ivertex, info.newVertices)
+                for(KeyVertex * ivertex: info.newVertices)
                 {
                     splitNodes.existing << EdgeSample(ivertex->pos()[0], ivertex->pos()[1]);
                     splitNodes.existingNodes << ivertex;
@@ -4028,10 +4028,10 @@ void VAC::insertSketchedEdgeInVAC(double tolerance, bool useFaceToConsiderForCut
                 KeyFace * iFace = newKeyFace(loopCycle);
                 iFace->setColor(hoveredFaceOnMousePress_->color());
                 InbetweenFaceSet sfacesbefore = hoveredFaceOnMousePress_->temporalStarBefore();
-                foreach(InbetweenFace * sface, sfacesbefore)
+                for(InbetweenFace * sface: sfacesbefore)
                     sface->addAfterFace(iFace);
                 InbetweenFaceSet sfacesafter = hoveredFaceOnMousePress_->temporalStarAfter();
-                foreach(InbetweenFace * sface, sfacesafter)
+                for(InbetweenFace * sface: sfacesafter)
                     sface->addBeforeFace(iFace);
             }
         }
@@ -4104,9 +4104,9 @@ void VAC::insertSketchedEdgeInVAC(double tolerance, bool useFaceToConsiderForCut
                     cutFace_(face,iedge, &feedback);
                     if(useFaceToConsiderForCutting)
                     {
-                        foreach(KeyFace * face, feedback.deletedFaces)
+                        for(KeyFace * face: feedback.deletedFaces)
                             facesToConsiderForCutting_.remove(face);
-                        foreach(KeyFace * face, feedback.newFaces)
+                        for(KeyFace * face: feedback.newFaces)
                             facesToConsiderForCutting_.insert(face);
                     }
                 }
@@ -4124,7 +4124,7 @@ void VAC::updateSculpt(double x, double y, Time time)
     KeyEdgeList iedges = instantEdges(timeInteractivity_);
     double minD = std::numeric_limits<double>::max();
     sculptedEdge_ = 0;
-    foreach(KeyEdge * iedge, iedges)
+    for(KeyEdge * iedge: iedges)
     {
         double d = iedge->updateSculpt(x, y, radius);
         if(d<radius && d<minD)
@@ -4249,7 +4249,7 @@ void findAnimatedVertexRec(KeyVertex * visitedVertex, KeyVertex * targetVertex, 
         else
         {
             InbetweenVertexSet svs = visitedVertex->temporalStarAfter();
-            foreach(InbetweenVertex * sv, svs)
+            for(InbetweenVertex * sv: svs)
             {
                 KeyVertex * afterVertex = sv->afterVertex();
                 if(afterVertex == targetVertex)
@@ -4365,7 +4365,7 @@ void VAC::inbetweenSelection()
     Time t1 = list[0]->time();
     Time t2;
     bool ok = false;
-    foreach(KeyCell * object, list)
+    for(KeyCell * object: list)
     {
         if(!ok) // didn't find t2 yet
         {
@@ -4397,7 +4397,7 @@ void VAC::inbetweenSelection()
     }
     KeyCellList list1;
     KeyCellList list2;
-    foreach(KeyCell * object, list)
+    for(KeyCell * object: list)
     {
         if(object->time() == t1)
             list1 << object;
@@ -4598,7 +4598,7 @@ void VAC::inbetweenSelection()
                 KeyVertex * vend2 = path2.endVertex();
                 InbetweenVertex * svstart = 0;
                 InbetweenVertexSet vstartAfter = vstart1->temporalStarAfter();
-                foreach(InbetweenVertex * sv, vstartAfter)
+                for(InbetweenVertex * sv: vstartAfter)
                     if(sv->afterVertex() == vstart2)
                         svstart = sv;
                 if(!svstart)
@@ -4609,7 +4609,7 @@ void VAC::inbetweenSelection()
                 if(!svend)
                 {
                     InbetweenVertexSet vendAfter = vend1->temporalStarAfter();
-                    foreach(InbetweenVertex * sv, vendAfter)
+                    for(InbetweenVertex * sv: vendAfter)
                         if(sv->afterVertex() == vend2)
                             svend = sv;
                 }
@@ -4683,7 +4683,7 @@ KeyCellSet VAC::keyframe_(const CellSet & cells, Time time)
 
     InbetweenCellSet inbetweenCells = cells;
     InbetweenCellSet relevantInbetweenCells;
-    foreach(InbetweenCell * scell, inbetweenCells)
+    for(InbetweenCell * scell: inbetweenCells)
     {
         if(scell->exists(time))
             relevantInbetweenCells << scell;
@@ -4692,19 +4692,19 @@ KeyCellSet VAC::keyframe_(const CellSet & cells, Time time)
     InbetweenVertexSet inbetweenVertices = relevantInbetweenCells;
     InbetweenEdgeSet inbetweenEdges = relevantInbetweenCells;
     InbetweenFaceSet inbetweenFaces = relevantInbetweenCells;
-    foreach(InbetweenVertex * svertex, inbetweenVertices)
+    for(InbetweenVertex * svertex: inbetweenVertices)
     {
         KeyCell * keyframedCell = keyframe_(svertex,time);
         if(keyframedCell)
             keyframedCells << keyframedCell;
     }
-    foreach(InbetweenEdge * sedge, inbetweenEdges)
+    for(InbetweenEdge * sedge: inbetweenEdges)
     {
         KeyCell * keyframedCell = keyframe_(sedge,time);
         if(keyframedCell)
             keyframedCells << keyframedCell;
     }
-    foreach(InbetweenFace * sface, inbetweenFaces)
+    for(InbetweenFace * sface: inbetweenFaces)
     {
         KeyCell * keyframedCell = keyframe_(sface,time);
         if(keyframedCell)
@@ -4734,7 +4734,7 @@ KeyVertex * VAC::keyframe_(InbetweenVertex * svertex, Time time)
     InbetweenCellSet spatialStar = svertex->spatialStar();
     InbetweenEdgeSet inbetweenEdgesToUpdate = spatialStar;
     InbetweenFaceSet inbetweenFacesToUpdate = spatialStar;
-    foreach(InbetweenEdge * sedge, inbetweenEdgesToUpdate)
+    for(InbetweenEdge * sedge: inbetweenEdgesToUpdate)
     {
         assert(!sedge->isClosed());
 
@@ -4748,7 +4748,7 @@ KeyVertex * VAC::keyframe_(InbetweenVertex * svertex, Time time)
 
         sedge->processGeometryChanged_();
     }
-    foreach(InbetweenFace * sface, inbetweenFacesToUpdate)
+    for(InbetweenFace * sface: inbetweenFacesToUpdate)
     {
         for(int k=0; k < sface->cycles_.size(); ++k)
         {
@@ -4791,7 +4791,7 @@ KeyEdge * VAC::keyframe_(InbetweenEdge * sedge, Time time)
     if(!sedge->isClosed())
     {
         VertexCellSet startVertices = sedge->startAnimatedVertex_.vertices();
-        foreach(VertexCell * v, startVertices)
+        for(VertexCell * v: startVertices)
         {
             if(v->exists(time))
             {
@@ -4805,7 +4805,7 @@ KeyEdge * VAC::keyframe_(InbetweenEdge * sedge, Time time)
         }
 
         VertexCellSet endVertices = sedge->endAnimatedVertex_.vertices();
-        foreach(VertexCell * v, endVertices)
+        for(VertexCell * v: endVertices)
         {
             if(v->exists(time))
             {
@@ -4881,7 +4881,7 @@ KeyEdge * VAC::keyframe_(InbetweenEdge * sedge, Time time)
     // Update incidence relationships
     InbetweenCellSet spatialStar = sedge->spatialStar();
     InbetweenFaceSet inbetweenFacesToUpdate = spatialStar;
-    foreach(InbetweenFace * sface, inbetweenFacesToUpdate)
+    for(InbetweenFace * sface: inbetweenFacesToUpdate)
     {
 
         for(int k=0; k < sface->cycles_.size(); ++k)
@@ -4929,13 +4929,13 @@ KeyFace * VAC::keyframe_(InbetweenFace * sface, Time time)
     {
         // Keyframes inbetween vertices in cycle
         InbetweenVertexSet sverticesInCycle = sface->animatedCycle(i).cells();
-        foreach(InbetweenVertex * svertex, sverticesInCycle)
+        for(InbetweenVertex * svertex: sverticesInCycle)
             if(svertex->exists(time))
                 keyframe_(svertex, time);
 
         // Keyframes inbetween edges in cycle
         InbetweenEdgeSet sedgesInCycle = sface->animatedCycle(i).cells();
-        foreach(InbetweenEdge * sedge, sedgesInCycle)
+        for(InbetweenEdge * sedge: sedgesInCycle)
             if(sedge->exists(time))
                 keyframe_(sedge, time);
     }
@@ -4965,19 +4965,19 @@ KeyFace * VAC::keyframe_(InbetweenFace * sface, Time time)
 
         // Compute all nodes to delete
         QSet<AnimatedCycleNode*> beforeCycleNodesToDelete;
-        foreach(AnimatedCycleNode * node, beforeCycle.nodes())
+        for(AnimatedCycleNode * node: beforeCycle.nodes())
             if(!node->cell()->isBefore(time))
                 beforeCycleNodesToDelete << node;
         QSet<AnimatedCycleNode*> afterCycleNodesToDelete;
-        foreach(AnimatedCycleNode * node, afterCycle.nodes())
+        for(AnimatedCycleNode * node: afterCycle.nodes())
             if(!node->cell()->isAfter(time))
                 afterCycleNodesToDelete << node;
 
         // Set pointers to deleted nodes to null instead
-        foreach(AnimatedCycleNode * node, beforeCycle.nodes())
+        for(AnimatedCycleNode * node: beforeCycle.nodes())
             if(beforeCycleNodesToDelete.contains(node->after()))
                 node->setAfter(0);
-        foreach(AnimatedCycleNode * node, afterCycle.nodes())
+        for(AnimatedCycleNode * node: afterCycle.nodes())
             if(afterCycleNodesToDelete.contains(node->before()))
                 node->setBefore(0);
 
@@ -4986,9 +4986,9 @@ KeyFace * VAC::keyframe_(InbetweenFace * sface, Time time)
         afterCycle.setFirst(afterCycleFirst);
 
         // Delete nodes to delete
-        foreach(AnimatedCycleNode * node, beforeCycleNodesToDelete)
+        for(AnimatedCycleNode * node: beforeCycleNodesToDelete)
             delete node;
-        foreach(AnimatedCycleNode * node, afterCycleNodesToDelete)
+        for(AnimatedCycleNode * node: afterCycleNodesToDelete)
             delete node;
 
         // Add cycles to new inbetween faces
@@ -5209,7 +5209,7 @@ QList<Cycle> VAC::createFace_computeCycles()
     vertexSet.subtract(verticesInClosureOfEdges);
 
     // Create steiner cycles
-    foreach(KeyVertex * v, vertexSet)
+    for(KeyVertex * v: vertexSet)
     {
         Cycle cycle(v);
         if(cycle.isValid())
@@ -5262,7 +5262,7 @@ void VAC::addCyclesToFace()
     }
     else
     {
-        foreach(KeyFace * face, faceSet)
+        for(KeyFace * face: faceSet)
             face->addCycles(cycles);
 
         emit needUpdatePicking();
@@ -5282,13 +5282,13 @@ void VAC::removeCyclesFromFace()
         return;
     }
 
-    foreach(KeyFace * face, faceSet)
+    for(KeyFace * face: faceSet)
     {
         QList<Cycle> newCycles;
         for(int i=0; i<face->cycles_.size(); ++i)
         {
             bool keepCycle = true;
-            foreach(KeyCell * cell, face->cycles_[i].cells())
+            for(KeyCell * cell: face->cycles_[i].cells())
             {
                 if(cell->isSelected())
                 {
@@ -5327,7 +5327,7 @@ void VAC::changeColor()
         QColor color = QColorDialog::getColor(initialColor, 0, tr("select the color for the selected cells"), QColorDialog::ShowAlphaChannel);
 
         if (color.isValid()) {
-            foreach(Cell * cell, selectedCells())
+            for(Cell * cell: selectedCells())
             {
                 cell->setColor(color);
             }
@@ -5446,7 +5446,7 @@ void VAC::changeEdgeWidth()
                                      tr("width:"), 10, 0, 100, 1, &ok);
         if (ok)
         {
-            foreach(KeyEdge * iedge, iedges)
+            for(KeyEdge * iedge: iedges)
             {
                 iedge->setWidth((double) i);
             }
@@ -5492,9 +5492,9 @@ void VAC::unglue()
     KeyVertexSet vertexSet = selectedCells();
     KeyEdgeSet edgeSet = selectedCells();
 
-    foreach(KeyEdge * iedge, edgeSet)
+    for(KeyEdge * iedge: edgeSet)
         unglue_(iedge);
-    foreach(KeyVertex * ivertex, vertexSet)
+    for(KeyVertex * ivertex: vertexSet)
         unglue_(ivertex);
 
     emit needUpdatePicking();
@@ -5509,9 +5509,9 @@ void VAC::uncut()
 
     bool hasbeenCut = false;
 
-    foreach(KeyEdge * iedge, edgeSet)
+    for(KeyEdge * iedge: edgeSet)
         hasbeenCut |= uncut_(iedge);
-    foreach(KeyVertex * ivertex, vertexSet)
+    for(KeyVertex * ivertex: vertexSet)
         hasbeenCut |= uncut_(ivertex);
 
     if(hasbeenCut)
@@ -5566,7 +5566,7 @@ void VAC::paste(VAC *& clipboard)
     // Offset clipboard VAC by deltaTime
     VAC * cloneOfClipboard = clipboard->clone();
     KeyCellSet keyCells = cloneOfClipboard->cells();
-    foreach(KeyCell * kc, keyCells)
+    for(KeyCell * kc: keyCells)
     {
         kc->time_ = kc->time_ + deltaTime;
     }
@@ -5612,7 +5612,7 @@ void VAC::motionPaste(VAC* & clipboard)
     // Offset clipboard VAC by deltaTime
     VAC * cloneOfClipboard = clipboard->clone();
     KeyCellSet keyCells = cloneOfClipboard->cells();
-    foreach(KeyCell * kc, keyCells)
+    for(KeyCell * kc: keyCells)
     {
         kc->time_ = kc->time_ + deltaTime;
     }
@@ -5820,7 +5820,7 @@ void VAC::informTimelineOfSelection()
     double t1 = 0;
     double t2 = 0;
 
-    foreach(Cell * cell, selectedCells_)
+    for(Cell * cell: selectedCells_)
     {
         KeyCell * keyCell = cell->toKeyCell();
         InbetweenCell * inbetweenCell = cell->toInbetweenCell();
@@ -5835,14 +5835,14 @@ void VAC::informTimelineOfSelection()
             }
 
             InbetweenCellSet beforeCells = keyCell->temporalStarBefore();
-            foreach(InbetweenCell * scell, beforeCells)
+            for(InbetweenCell * scell: beforeCells)
             {
                 double tbefore = scell->beforeTime().floatTime();
                 t1 = std::max(tbefore,t1);
             }
 
             InbetweenCellSet afterCells = keyCell->temporalStarAfter();
-            foreach(InbetweenCell * scell, afterCells)
+            for(InbetweenCell * scell: afterCells)
             {
                 double tafter = scell->afterTime().floatTime();
                 t2 = std::min(tafter,t2);
@@ -5914,7 +5914,7 @@ void VAC::toggleSelection(Cell * cell, bool emitSignal)
 void VAC::addToSelection(const CellSet & cells, bool emitSignal)
 {
     beginAggregateSignals_();
-    foreach(Cell * c, cells)
+    for(Cell * c: cells)
         addToSelection(c, false);
     endAggregateSignals_();
 
@@ -5927,7 +5927,7 @@ void VAC::addToSelection(const CellSet & cells, bool emitSignal)
 void VAC::removeFromSelection(const CellSet & cells, bool emitSignal)
 {
     beginAggregateSignals_();
-    foreach(Cell * c, cells)
+    for(Cell * c: cells)
         removeFromSelection(c, false);
     endAggregateSignals_();
 
@@ -5941,7 +5941,7 @@ void VAC::removeFromSelection(const CellSet & cells, bool emitSignal)
 void VAC::toggleSelection(const CellSet & cells, bool emitSignal)
 {
     beginAggregateSignals_();
-    foreach(Cell * c, cells)
+    for(Cell * c: cells)
         toggleSelection(c, false);
     endAggregateSignals_();
 
@@ -5967,7 +5967,7 @@ void VAC::setSelectedCells(const CellSet & cells, bool emitSignal)
 
     // Detect if any new cell is added to the selection, and set
     // all new cells as unselected.
-    foreach(Cell * cell, cells)
+    for(Cell * cell: cells)
     {
         if (cell->isSelected())
         {
@@ -5983,7 +5983,7 @@ void VAC::setSelectedCells(const CellSet & cells, bool emitSignal)
     // all old cells as unselected.
     // This works due to the previous step: any cell in selectedCells_
     // which is still selected is *not* in the new cells.
-    foreach(Cell * cell, selectedCells_)
+    for(Cell * cell: selectedCells_)
     {
         if (cell->isSelected())
         {
@@ -5993,7 +5993,7 @@ void VAC::setSelectedCells(const CellSet & cells, bool emitSignal)
     }
 
     // Set new cells as selected
-    foreach(Cell * cell, cells)
+    for(Cell * cell: cells)
         cell->setSelected(true);
     selectedCells_ = cells;
 
@@ -6030,7 +6030,7 @@ void VAC::selectClosure(bool emitSignal)
 void VAC::selectVertices(bool emitSignal)
 {
     CellSet cellsToSelect;
-    foreach(Cell * c, selectedCells())
+    for(Cell * c: selectedCells())
         if(c->toVertexCell())
             cellsToSelect.insert(c);
 
@@ -6040,7 +6040,7 @@ void VAC::selectVertices(bool emitSignal)
 void VAC::selectEdges(bool emitSignal)
 {
     CellSet cellsToSelect;
-    foreach(Cell * c, selectedCells())
+    for(Cell * c: selectedCells())
         if(c->toEdgeCell())
             cellsToSelect.insert(c);
 
@@ -6050,7 +6050,7 @@ void VAC::selectEdges(bool emitSignal)
 void VAC::selectFaces(bool emitSignal)
 {
     CellSet cellsToSelect;
-    foreach(Cell * c, selectedCells())
+    for(Cell * c: selectedCells())
         if(c->toFaceCell())
             cellsToSelect.insert(c);
 
@@ -6060,7 +6060,7 @@ void VAC::selectFaces(bool emitSignal)
 void VAC::deselectVertices(bool emitSignal)
 {
     CellSet cellsToSelect;
-    foreach(Cell * c, selectedCells())
+    for(Cell * c: selectedCells())
         if(!c->toVertexCell())
             cellsToSelect.insert(c);
 
@@ -6070,7 +6070,7 @@ void VAC::deselectVertices(bool emitSignal)
 void VAC::deselectEdges(bool emitSignal)
 {
     CellSet cellsToSelect;
-    foreach(Cell * c, selectedCells())
+    for(Cell * c: selectedCells())
         if(!c->toEdgeCell())
             cellsToSelect.insert(c);
 
@@ -6080,7 +6080,7 @@ void VAC::deselectEdges(bool emitSignal)
 void VAC::deselectFaces(bool emitSignal)
 {
     CellSet cellsToSelect;
-    foreach(Cell * c, selectedCells())
+    for(Cell * c: selectedCells())
         if(!c->toFaceCell())
             cellsToSelect.insert(c);
 
@@ -6090,7 +6090,7 @@ void VAC::deselectFaces(bool emitSignal)
 void VAC::selectKeyCells(bool emitSignal)
 {
     CellSet cellsToSelect;
-    foreach(Cell * c, selectedCells())
+    for(Cell * c: selectedCells())
         if(c->toKeyCell())
             cellsToSelect.insert(c);
 
@@ -6100,7 +6100,7 @@ void VAC::selectKeyCells(bool emitSignal)
 void VAC::selectInbetweenCells(bool emitSignal)
 {
     CellSet cellsToSelect;
-    foreach(Cell * c, selectedCells())
+    for(Cell * c: selectedCells())
         if(c->toInbetweenCell())
             cellsToSelect.insert(c);
 
@@ -6110,7 +6110,7 @@ void VAC::selectInbetweenCells(bool emitSignal)
 void VAC::deselectKeyCells(bool emitSignal)
 {
     CellSet cellsToSelect;
-    foreach(Cell * c, selectedCells())
+    for(Cell * c: selectedCells())
         if(!c->toKeyCell())
             cellsToSelect.insert(c);
 
@@ -6120,7 +6120,7 @@ void VAC::deselectKeyCells(bool emitSignal)
 void VAC::deselectInbetweenCells(bool emitSignal)
 {
     CellSet cellsToSelect;
-    foreach(Cell * c, selectedCells())
+    for(Cell * c: selectedCells())
         if(!c->toInbetweenCell())
             cellsToSelect.insert(c);
 
@@ -6130,7 +6130,7 @@ void VAC::deselectInbetweenCells(bool emitSignal)
 void VAC::selectKeyVertices(bool emitSignal)
 {
     CellSet cellsToSelect;
-    foreach(Cell * c, selectedCells())
+    for(Cell * c: selectedCells())
         if(c->toKeyVertex())
             cellsToSelect.insert(c);
 
@@ -6140,7 +6140,7 @@ void VAC::selectKeyVertices(bool emitSignal)
 void VAC::selectKeyEdges(bool emitSignal)
 {
     CellSet cellsToSelect;
-    foreach(Cell * c, selectedCells())
+    for(Cell * c: selectedCells())
         if(c->toKeyEdge())
             cellsToSelect.insert(c);
 
@@ -6150,7 +6150,7 @@ void VAC::selectKeyEdges(bool emitSignal)
 void VAC::selectKeyFaces(bool emitSignal)
 {
     CellSet cellsToSelect;
-    foreach(Cell * c, selectedCells())
+    for(Cell * c: selectedCells())
         if(c->toKeyFace())
             cellsToSelect.insert(c);
 
@@ -6160,7 +6160,7 @@ void VAC::selectKeyFaces(bool emitSignal)
 void VAC::deselectKeyVertices(bool emitSignal)
 {
     CellSet cellsToSelect;
-    foreach(Cell * c, selectedCells())
+    for(Cell * c: selectedCells())
         if(!c->toKeyVertex())
             cellsToSelect.insert(c);
 
@@ -6170,7 +6170,7 @@ void VAC::deselectKeyVertices(bool emitSignal)
 void VAC::deselectKeyEdges(bool emitSignal)
 {
     CellSet cellsToSelect;
-    foreach(Cell * c, selectedCells())
+    for(Cell * c: selectedCells())
         if(!c->toKeyEdge())
             cellsToSelect.insert(c);
 
@@ -6180,7 +6180,7 @@ void VAC::deselectKeyEdges(bool emitSignal)
 void VAC::deselectKeyFaces(bool emitSignal)
 {
     CellSet cellsToSelect;
-    foreach(Cell * c, selectedCells())
+    for(Cell * c: selectedCells())
         if(!c->toKeyFace())
             cellsToSelect.insert(c);
 
@@ -6190,7 +6190,7 @@ void VAC::deselectKeyFaces(bool emitSignal)
 void VAC::selectInbetweenVertices(bool emitSignal)
 {
     CellSet cellsToSelect;
-    foreach(Cell * c, selectedCells())
+    for(Cell * c: selectedCells())
         if(c->toInbetweenVertex())
             cellsToSelect.insert(c);
 
@@ -6200,7 +6200,7 @@ void VAC::selectInbetweenVertices(bool emitSignal)
 void VAC::selectInbetweenEdges(bool emitSignal)
 {
     CellSet cellsToSelect;
-    foreach(Cell * c, selectedCells())
+    for(Cell * c: selectedCells())
         if(c->toInbetweenEdge())
             cellsToSelect.insert(c);
 
@@ -6210,7 +6210,7 @@ void VAC::selectInbetweenEdges(bool emitSignal)
 void VAC::selectInbetweenFaces(bool emitSignal)
 {
     CellSet cellsToSelect;
-    foreach(Cell * c, selectedCells())
+    for(Cell * c: selectedCells())
         if(c->toInbetweenFace())
             cellsToSelect.insert(c);
 
@@ -6220,7 +6220,7 @@ void VAC::selectInbetweenFaces(bool emitSignal)
 void VAC::deselectInbetweenVertices(bool emitSignal)
 {
     CellSet cellsToSelect;
-    foreach(Cell * c, selectedCells())
+    for(Cell * c: selectedCells())
         if(!c->toInbetweenVertex())
             cellsToSelect.insert(c);
 
@@ -6230,7 +6230,7 @@ void VAC::deselectInbetweenVertices(bool emitSignal)
 void VAC::deselectInbetweenEdges(bool emitSignal)
 {
     CellSet cellsToSelect;
-    foreach(Cell * c, selectedCells())
+    for(Cell * c: selectedCells())
         if(!c->toInbetweenEdge())
             cellsToSelect.insert(c);
 
@@ -6240,7 +6240,7 @@ void VAC::deselectInbetweenEdges(bool emitSignal)
 void VAC::deselectInbetweenFaces(bool emitSignal)
 {
     CellSet cellsToSelect;
-    foreach(Cell * c, selectedCells())
+    for(Cell * c: selectedCells())
         if(!c->toInbetweenFace())
             cellsToSelect.insert(c);
 
@@ -6273,7 +6273,7 @@ void VAC::prepareDragAndDrop(double x0, double y0, Time time)
     // Partition into three sets of cells
     CellSet cellsNotToKeyframe;
     CellSet cellsToKeyframe;
-    foreach(Cell * c, cellsToDrag)
+    for(Cell * c: cellsToDrag)
     {
         InbetweenCell * sc = c->toInbetweenCell();
         if(sc)
@@ -6298,7 +6298,7 @@ void VAC::prepareDragAndDrop(double x0, double y0, Time time)
 
     // Update which cells to drag
     cellsToDrag = cellsNotToKeyframe;
-    foreach(KeyCell * c, keyframedCells)
+    for(KeyCell * c: keyframedCells)
         cellsToDrag << c;
     cellsToDrag = Algorithms::closure(cellsToDrag);
 
@@ -6307,9 +6307,9 @@ void VAC::prepareDragAndDrop(double x0, double y0, Time time)
     draggedEdges_ = KeyEdgeSet(cellsToDrag);
 
     // prepare drag and drop
-    foreach(KeyEdge * iedge, draggedEdges_)
+    for(KeyEdge * iedge: draggedEdges_)
         iedge->geometry()->prepareDragAndDrop();
-    foreach(KeyVertex * v, draggedVertices_)
+    for(KeyVertex * v: draggedVertices_)
         v->prepareDragAndDrop();
 
     x0_ = x0;
@@ -6337,17 +6337,17 @@ void VAC::performDragAndDrop(double x, double y)
         else if (std::abs(theta + 3*PI/4) <   PI/8) { dx = -d; dy = -d; }
     }
 
-    foreach(KeyEdge * iedge, draggedEdges_)
+    for(KeyEdge * iedge: draggedEdges_)
     {
         iedge->geometry()->performDragAndDrop(dx, dy);
         iedge->processGeometryChanged_();
     }
 
-    foreach(KeyVertex * v, draggedVertices_)
+    for(KeyVertex * v: draggedVertices_)
         v->performDragAndDrop(dx, dy);
 
 
-    foreach(KeyVertex * v, draggedVertices_)
+    for(KeyVertex * v: draggedVertices_)
         v->correctEdgesGeometry();
 
     transformTool_.performDragAndDrop(dx, dy);
@@ -6390,7 +6390,7 @@ void VAC::prepareTemporalDragAndDrop(Time t0)
     deltaTMin_ = Time(-1000);
     deltaTMax_ = Time(1000);
 
-    foreach(KeyCell * keyCell, draggedKeyCells_)
+    for(KeyCell * keyCell: draggedKeyCells_)
     {
         Time deltaTMin = keyCell->temporalDragMinTime() - keyCell->time();
         if(deltaTMin_ < deltaTMin)
@@ -6412,7 +6412,7 @@ void VAC::performTemporalDragAndDrop(Time t)
     if(deltaTime >= deltaTMax_)
         return;
 
-    foreach(KeyCell * keyCell, draggedKeyCells_)
+    for(KeyCell * keyCell: draggedKeyCells_)
         keyCell->setTime(draggedKeyCellTime_[keyCell] + deltaTime);
 
     emit changed();
@@ -6493,7 +6493,7 @@ KeyVertex * VAC::split(double x, double y, Time time, bool interactive)
             // This possibly craete many straight lines at once
             KeyVertexSet selectedVertices = selectedCells();
             KeyEdgeSet newEdges;
-            foreach(KeyVertex * selectedVertex, selectedVertices)
+            for(KeyVertex * selectedVertex: selectedVertices)
             {
                 newEdges << newKeyEdge(time, selectedVertex, res, 0, global()->edgeWidth());
             }
@@ -6507,7 +6507,7 @@ KeyVertex * VAC::split(double x, double y, Time time, bool interactive)
         {
             KeyVertexSet selectedVertices = selectedCells();
 
-            foreach(KeyVertex * selectedVertex, selectedVertices)
+            for(KeyVertex * selectedVertex: selectedVertices)
             {
                 // Tolerance accounting for floating point errors
                 double tolerance = 1e-6;
@@ -6557,7 +6557,7 @@ KeyVertex * VAC::split(double x, double y, Time time, bool interactive)
 
 bool VAC::check() const
 {
-    foreach(Cell * c, cells_)
+    for(Cell * c: cells_)
         if(!(c->check()))
             return false;
     return true;
@@ -6591,7 +6591,7 @@ void VAC::updateToBePaintedFace(double x, double y, Time time)
 
     // Compute distances to all edges
     QMap<KeyEdge*,EdgeGeometry::ClosestVertexInfo> distancesToEdges;
-    foreach(KeyEdge * e, instantEdges())
+    for(KeyEdge * e: instantEdges())
         distancesToEdges[e] = e->geometry()->closestPoint(x,y);
 
     // First, we try to create such a face assuming that the
@@ -6600,7 +6600,7 @@ void VAC::updateToBePaintedFace(double x, double y, Time time)
     {
         // Find external boundary: the closest planar cycle containing mouse cursor
         QSet<KeyEdge*> potentialExternalBoundaryEdges;
-        foreach(KeyEdge* e, instantEdges())
+        for(KeyEdge* e: instantEdges())
         {
             if(e->exists(time))
                 potentialExternalBoundaryEdges.insert(e);
@@ -6614,7 +6614,7 @@ void VAC::updateToBePaintedFace(double x, double y, Time time)
             EdgeGeometry::ClosestVertexInfo cvi;
             cvi.s = 0;
             cvi.d = std::numeric_limits<double>::max();
-            foreach(KeyEdge * e, potentialExternalBoundaryEdges)
+            for(KeyEdge * e: potentialExternalBoundaryEdges)
             {
                 EdgeGeometry::ClosestVertexInfo cvi_e = distancesToEdges[e];
                 if(cvi_e.d < cvi.d) // TODO: cvi_e.d could be NaN, in which case it returns false, and closestPotentialExternalBoundaryEdge can be null, resulting in a segfault 8 lines below.
@@ -6691,7 +6691,7 @@ void VAC::updateToBePaintedFace(double x, double y, Time time)
                 // If not found (maxIter reached or edge already rejected)
                 if(!foundPotentialPlanarCycle)
                 {
-                    foreach(KeyHalfedge he, potentialPlanarCycle)
+                    for(KeyHalfedge he: potentialPlanarCycle)
                     {
                         potentialExternalBoundaryEdges.remove(he.edge);
                     }
@@ -6708,7 +6708,7 @@ void VAC::updateToBePaintedFace(double x, double y, Time time)
                         }
                         else
                         {
-                            foreach(KeyHalfedge he, potentialPlanarCycle)
+                            for(KeyHalfedge he: potentialPlanarCycle)
                             {
                                 potentialExternalBoundaryEdges.remove(he.edge);
                             }
@@ -6717,7 +6717,7 @@ void VAC::updateToBePaintedFace(double x, double y, Time time)
                     }
                     else
                     {
-                        foreach(KeyHalfedge he, potentialPlanarCycle)
+                        for(KeyHalfedge he: potentialPlanarCycle)
                         {
                             potentialExternalBoundaryEdges.remove(he.edge);
                         }
@@ -6737,14 +6737,14 @@ void VAC::updateToBePaintedFace(double x, double y, Time time)
 
             // Now, let's try to add holes to the external boundary
             QSet<KeyEdge*> potentialHoleEdges;
-            foreach(KeyEdge* e, instantEdges())
+            for(KeyEdge* e: instantEdges())
             {
                 if(e->exists(time))
                     potentialHoleEdges.insert(e);
             }
             CellSet cellsInExternalBoundary = externalBoundary.cycles()[0].cells();
             KeyEdgeSet edgesInExternalBoundary = cellsInExternalBoundary;
-            foreach(KeyEdge * e, edgesInExternalBoundary)
+            for(KeyEdge * e: edgesInExternalBoundary)
                 potentialHoleEdges.remove(e);
             QList<PreviewKeyFace> holes;
             while(!potentialHoleEdges.isEmpty())

--- a/src/VAC/VectorAnimationComplex/VertexCell.cpp
+++ b/src/VAC/VectorAnimationComplex/VertexCell.cpp
@@ -159,7 +159,7 @@ double VertexCell::size(Time time) const
 
     // valence > 0
     double res = 0; //std::numeric_limits<double>::max();
-    foreach(Halfedge h, incidentEdgesT)
+    for(Halfedge h: incidentEdgesT)
     {
         EdgeSample sample = h.startSample(time);
         if(sample.width() > res)
@@ -214,14 +214,14 @@ QList<Halfedge> VertexCell::incidentEdges(Time t) const
     // Orient them so that "start(h) = this"
     // Note: Possibly add them twice if start = end = this
     QList<Halfedge> res;
-    foreach(KeyEdge * keyEdge, keyEdges)
+    for(KeyEdge * keyEdge: keyEdges)
     {
         if(keyEdge->startVertex()->toVertexCell() == this)
             res << Halfedge(keyEdge, true);
         if(keyEdge->endVertex()->toVertexCell() == this)
             res << Halfedge(keyEdge, false);
     }
-    foreach(InbetweenEdge * inbetweenEdge, inbetweenEdges)
+    for(InbetweenEdge * inbetweenEdge: inbetweenEdges)
     {
         if(inbetweenEdge->startVertex(t)->toVertexCell()  == this)
             res << Halfedge(inbetweenEdge, true);

--- a/src/VAC/VectorAnimationComplex/ZOrderedCells.cpp
+++ b/src/VAC/VectorAnimationComplex/ZOrderedCells.cpp
@@ -149,7 +149,7 @@ namespace // local free function
 
 bool intersect(Cell * c, const CellSet & cells)
 {
-    foreach(Cell * c2, cells)
+    for(Cell * c2: cells)
         if(c->boundingBox().intersects(c2->boundingBox()))
             return true;
     return false;

--- a/src/VAC/View3D.cpp
+++ b/src/VAC/View3D.cpp
@@ -1060,7 +1060,7 @@ bool View3D::exportMesh(QString filename)
     for (Eigen::Vector3d& p : positions) {
         out << "v " << s * p[0] << " " << s * p[1] << " " << s * p[2] << "\n";
     }
-    for (Eigen::Vector3d p : normals) {
+    for (Eigen::Vector3d p : qAsConst(normals)) {
         p.normalize();
         out << "vn " << p[0] << " " << p[1] << " " << p[2] << "\n";
     }


### PR DESCRIPTION
As titled. 
This brings the codebase closer to native C++ standards and algorithms.

---
https://doc-snapshots.qt.io/qt6-dev/foreach-keyword.html
> Note: The foreach keyword was introduced before the C++11 range-based loops existed. New code should prefer C++11 range-based loops.
