### PR TITLE
Replace qSort for std::sort

### DIFF
--- a/src/VAC/AnimatedCycleWidget.cpp
+++ b/src/VAC/AnimatedCycleWidget.cpp
@@ -967,7 +967,7 @@ void AnimatedCycleWidget::computeItemHeightAndY()
 
     // Sort key times and compute height and Y of items
     QList<int> keyTimesSorted = keyTimes.toList();
-    qSort(keyTimesSorted);
+    std::sort(std::begin(keyTimesSorted), std::end(keyTimesSorted));
     for(Iterator it = nodeToItem_.begin(); it != nodeToItem_.end(); ++it)
     {
         AnimatedCycleNode * node = it.key();

--- a/src/VAC/VectorAnimationComplex/Intersection.h
+++ b/src/VAC/VectorAnimationComplex/Intersection.h
@@ -78,8 +78,8 @@ class Q_VPAINT_EXPORT IntersectionList: public QList<Intersection*>
 {
 public:
 
-    void sort() {qSort(begin(), end(), Intersection::pLessThanS);}
-    void sortT() {qSort(begin(), end(), Intersection::pLessThanT);}
+    void sort() {std::sort(begin(), end(), Intersection::pLessThanS);}
+    void sortT() {std::sort(begin(), end(), Intersection::pLessThanT);}
 
     void clean()
     {

--- a/src/VAC/VectorAnimationComplex/KeyHalfedge.cpp
+++ b/src/VAC/VectorAnimationComplex/KeyHalfedge.cpp
@@ -167,7 +167,7 @@ QList<KeyHalfedge> KeyHalfedge::sorted(const QList<KeyHalfedge> & adj)
     }
 
     // sort the he according to this angle
-    qSort(list);
+    std::sort(std::begin(list), std::end(list));
 
     // return the he sorted
     QList<KeyHalfedge> res;


### PR DESCRIPTION
`qSort` has been phased out for `std::sort`