### PR TITLE
[BIOX-2745] Restrict the user to draw outside the surface area

### DIFF
--- a/src/VAC/Global.cpp
+++ b/src/VAC/Global.cpp
@@ -24,6 +24,9 @@
 #include "DevSettings.h"
 #include "ColorSelector.h"
 #include "Timeline.h"
+#include "VectorAnimationComplex/KeyVertex.h"
+#include "VAC/VectorAnimationComplex/EdgeGeometry.h"
+#include "VAC/VectorAnimationComplex/EdgeSample.h"
 
 #include <QDebug>
 #include <QApplication>
@@ -83,8 +86,11 @@ Global::Global(MainWindow * w) :
     gridSize_(1.0),
     pasteDeltaX_(15),
     pasteDeltaY_(15),
-    selectedGeometry_{0, 0, 0, 0},
-    mousePastePosition_{0, 0},
+    skippingCurveSamples_(2),
+    selectedGeometry_{0.0, 0.0, 0.0, 0.0},
+    mousePastePosition_{0.0, 0.0},
+    sceneCenterPosition_{0.0, 0.0},
+    arrowKeysMoveDelta_{1.0, 1.0},
     surfaceType_(VPaint::SurfaceType::None),
     surfaceBackGroundColor_{QColor(Qt::white)},
     surfaceBorderColor_{QColor(Qt::darkGray)},
@@ -1049,6 +1055,8 @@ void Global::setSurfaceScaleFactor(double scaleFactor)
 {
     surfaceScaleFactor_ = scaleFactor;
     gridSize_ = gridSizeMM_ * scaleFactor;
+    sceneCenterPosition_.setX(scene()->left() + scene()->width() / 2);
+    sceneCenterPosition_.setY(scene()->top() + scene()->height() / 2);
 }
 
 void Global::setGridSize(double gridSizeMM)
@@ -1121,6 +1129,98 @@ QPointF Global::getSnappedPosition(const QPointF& pos)
     auto yRes = pos.y();
     calculateSnappedPosition(xRes, yRes);
     return QPointF(xRes, yRes);
+}
+
+bool Global::isPointInSurface(const double x, const double y) const
+{
+    auto result = false;
+    switch (surfaceType_) {
+    case VPaint::SurfaceType::WellPlate:
+    case VPaint::SurfaceType::PetriDish:
+    {
+        const auto radius = scene()->width() / 2;
+        const auto deltaX = x - sceneCenterPosition_.x();
+        const auto deltaY = y - sceneCenterPosition_.y();
+        const auto distanceToCenter2 = deltaX * deltaX + deltaY * deltaY;
+        result = distanceToCenter2 <= radius * radius;
+        break;
+    }
+    case VPaint::SurfaceType::GlassSlide:
+    {
+        const auto xMin = scene()->left();
+        const auto yMin = scene()->top();
+        const auto xMax = xMin + scene()->width();
+        const auto yMax = yMin + scene()->height();
+        result = x >= xMin && y >= yMin && x <= xMax && y <= yMax;
+        break;
+    }
+    default:
+        break;
+    }
+
+    return result;
+}
+
+bool Global::isShapeInSurface(const VectorAnimationComplex::KeyVertexSet& vertices, const VectorAnimationComplex::KeyEdgeSet& edges, const QPointF delta) const
+{
+    // Check all vertices
+    for (auto vertex : vertices)
+    {
+        const auto vx = vertex->pos()[0];
+        const auto vy = vertex->pos()[1];
+        if (!isPointInSurface(vx + delta.x(), vy + delta.y()))
+            return false;
+    }
+
+    // Check samples of all edges(curves only)
+    for (auto edge : edges)
+    {
+        if (edge->shapeType() == ShapeType::CURVE) {
+            const auto samples = edge->geometry()->sampling();
+            const auto inc = skippingCurveSamples() + 1;
+            for (auto i = 0; i < samples.count(); i += inc)
+            {
+                const auto sample = samples[i];
+                if (!isPointInSurface(sample[0] + delta.x(), sample[1] + delta.y()))
+                    return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+bool Global::isShapeInSurface(const QVector<QPointF>& vertices) const
+{
+    for (auto position : vertices)
+    {
+        if (!isPointInSurface(position.x(), position.y()))
+            return false;
+    }
+    return true;
+}
+
+void Global::setArrowKeysMoveDelta(const double delta)
+{
+    arrowKeysMoveDelta_.setX(delta);
+    arrowKeysMoveDelta_.setY(delta);
+}
+
+void Global::setArrowKeysMoveDelta(const double deltaX, const double deltaY)
+{
+    arrowKeysMoveDelta_.setX(deltaX);
+    arrowKeysMoveDelta_.setY(deltaY);
+}
+
+void Global::setArrowKeysMoveDelta(const QPointF& delta)
+{
+    arrowKeysMoveDelta_.setX(delta.x());
+    arrowKeysMoveDelta_.setY(delta.y());
+}
+
+void Global::setSkippingCurveSamples(const int value)
+{
+    skippingCurveSamples_ = value;
 }
 
 bool Global::useTabletPressure() const

--- a/src/VAC/Global.h
+++ b/src/VAC/Global.h
@@ -34,6 +34,7 @@
 #include <QLabel>
 #include <QDir>
 #include "VAC/vpaint_global.h"
+#include "VectorAnimationComplex/CellList.h"
 
 class QHBoxLayout;
 class DevSettings;
@@ -203,6 +204,23 @@ public:
     void calculateSnappedPosition(QPointF& pos);
     QPointF getSnappedPosition(double x, double y);
     QPointF getSnappedPosition(const QPointF& pos);
+
+    bool isPointInSurface(const double x, const double y) const;
+    bool isShapeInSurface(const VectorAnimationComplex::KeyVertexSet& vertices, const VectorAnimationComplex::KeyEdgeSet& edges, const QPointF delta) const;
+    bool isShapeInSurface(const QVector<QPointF>& vertices) const;
+
+    // A delta in millimeters used for moving shapes by
+    // keyboard arrow keys(default: 1.0 mm for both directions)
+    // If the grid snapping is enabled - delta will be the grid size
+    inline const QPointF& arrowKeysMoveDelta() const { return arrowKeysMoveDelta_; }
+    void setArrowKeysMoveDelta(const double delta);
+    void setArrowKeysMoveDelta(const double deltaX, const double deltaY);
+    void setArrowKeysMoveDelta(const QPointF& delta);
+
+    // Count of skipping samples when checking they on inscribe into surface for
+    // improve performance, because a curve line contains a lot of samples.
+    inline int skippingCurveSamples() const { return skippingCurveSamples_; }
+    void setSkippingCurveSamples(const int value);
 
     // Display modes
     enum DisplayMode {
@@ -375,8 +393,13 @@ private:
     double pasteDeltaX_;
     double pasteDeltaY_;
 
+    int skippingCurveSamples_;
+
     QRectF selectedGeometry_;
     QPointF mousePastePosition_;
+    QPointF sceneCenterPosition_;
+
+    QPointF arrowKeysMoveDelta_;
 
     VPaint::SurfaceType surfaceType_;
     QColor surfaceBackGroundColor_;

--- a/src/VAC/MainWindow.cpp
+++ b/src/VAC/MainWindow.cpp
@@ -610,11 +610,11 @@ void MainWindow::parseKeyPressEvent(QKeyEvent* event)
     }
     else if (keySequence == QKeySequence(QKeySequence::Delete))
     {
-        scene()->deleteSelectedCells();
+        scene()->smartDelete();
     }
     else if (keySequence == QKeySequence(Qt::CTRL + Qt::Key_Delete))
     {
-        scene()->smartDelete();
+        scene()->deleteSelectedCells();
     }
 
     event->ignore();

--- a/src/VAC/VectorAnimationComplex/BoundingBox.cpp
+++ b/src/VAC/VectorAnimationComplex/BoundingBox.cpp
@@ -183,4 +183,12 @@ bool BoundingBox::operator!=(const BoundingBox & other) const
     return !(*this == other);
 }
 
+void BoundingBox::reset()
+{
+    xMin_ = INF;
+    xMax_ = -INF;
+    yMin_ = INF;
+    yMax_ = -INF;
+}
+
 }

--- a/src/VAC/VectorAnimationComplex/BoundingBox.h
+++ b/src/VAC/VectorAnimationComplex/BoundingBox.h
@@ -257,6 +257,8 @@ public:
     // Comparison operators
     bool operator==(const BoundingBox & other) const;
     bool operator!=(const BoundingBox & other) const;
+
+    void reset();
     
 private:
     // Data members

--- a/src/VAC/VectorAnimationComplex/EdgeGeometry.cpp
+++ b/src/VAC/VectorAnimationComplex/EdgeGeometry.cpp
@@ -1222,6 +1222,8 @@ void LinearSpline::performDragAndDrop(double dx, double dy)
 void LinearSpline::prepareAffineTransform()
 {
     curveBeforeTransform_ = curve_;
+    samplingBeforeTransform_.clear();
+    samplingBeforeTransform_.append(sampling_);
 }
 
 void LinearSpline::performAffineTransform(const Eigen::Affine2d & xf)

--- a/src/VAC/VectorAnimationComplex/EdgeGeometry.h
+++ b/src/VAC/VectorAnimationComplex/EdgeGeometry.h
@@ -117,6 +117,8 @@ public:
     bool isClosed() const {return isClosed_;}
     void makeLoop() { isClosed_ = true; makeLoop_(); }
 
+    inline const QList<Eigen::Vector2d>& samplingBeforeTransform() const { return samplingBeforeTransform_; }
+
     // Closest vertex queries
     struct ClosestVertexInfo {
         EdgeSample p; // closest point
@@ -140,6 +142,7 @@ protected:
     virtual void makeLoop_() {}
     bool isClosed_;
 
+    QList<Eigen::Vector2d> samplingBeforeTransform_{};
 
 private:
     double ds_;

--- a/src/VAC/VectorAnimationComplex/KeyVertex.h
+++ b/src/VAC/VectorAnimationComplex/KeyVertex.h
@@ -39,6 +39,7 @@ public:
     Eigen::Vector2d pos(Time ) const
         { return pos(); }
     Eigen::Vector2d pos() const;
+    inline const Eigen::Vector2d& posBack() const { return posBack_; }
     //double size() const;
     //double size(Time time) const;
     void computePosFromEdges();

--- a/src/VAC/VectorAnimationComplex/TransformTool.h
+++ b/src/VAC/VectorAnimationComplex/TransformTool.h
@@ -87,7 +87,7 @@ public:
     // Transform selection
     void beginTransform(double x0, double y0, Time time);
     // Added the angle parameter for the manual rotating
-    void continueTransform(double x, double y, double angle = 0.0);
+    bool continueTransform(double x, double y, double angle = 0.0);
     void endTransform();
 
     // Drag and drop transform tool
@@ -97,7 +97,7 @@ public:
 
     void setManualWidth(double newWidth, Time time);
     void setManualHeight(double newHeight, Time time);
-    void setManualRotation(double angle, Time time);
+    bool setManualRotation(double angle, Time time);
 
 private slots:
     void onKeyboardModifiersChanged();
@@ -161,6 +161,7 @@ private:
     double x0_, y0_, dx_, dy_, x_, y_;
     BoundingBox bb0_, obb0_;
     double dTheta_;
+    Time startTransformTime_;
 };
 
 }

--- a/src/VAC/VectorAnimationComplex/VAC.cpp
+++ b/src/VAC/VectorAnimationComplex/VAC.cpp
@@ -1512,6 +1512,7 @@ void VAC::deleteCell(Cell * cell)
 
     // Finally, now that no pointers point to the cell, release memory
     delete cell;
+    cell = nullptr;
 }
 
 // Smart deletion and simplification

--- a/src/VAC/VectorAnimationComplex/VAC.h
+++ b/src/VAC/VectorAnimationComplex/VAC.h
@@ -104,6 +104,7 @@ public:
     const CellSet & selectedCells() const;
     const CellSet& hoveredCells() const;
     int numSelectedCells() const;
+    inline const bool hasSelectedCells() const { return selectedCells_.count() != 0; }
 
     // Get hovered transform widget id
     int hoveredTransformWidgetId() const;
@@ -162,6 +163,8 @@ public:
     void prepareDragAndDrop(double x0, double y0, Time time);
     void performDragAndDrop(double x, double y);
     void completeDragAndDrop(bool emitCheckpoint = true);
+    inline const KeyVertexSet& draggedVertices() const { return draggedVertices_; }
+    inline const KeyEdgeSet& draggedEdges() const { return draggedEdges_; }
 
     // -- Transform selection --
     void beginTransformSelection(double x0, double y0, Time time);
@@ -214,12 +217,17 @@ public:
 
     void calculateSelectedGeometry();
 
+    BoundingBox selectedBoundingBox() const;
+    BoundingBox selectedOutlineBoundingBox() const;
+
     void setManualWidth(double newWidth);
     void setManualHeight(double newHeight);
-    void setManualRotation(double angle);
+    bool setManualRotation(double angle);
 
     void assignShapeID(Cell* cell);
     void endDrawShape();
+
+    QPointF dragStartPosition() const;
 
     /////////////////////////////////////////////////////////////////
     //                 MOUSE CLIC ACTIONS                          //
@@ -505,7 +513,7 @@ private:
     bool isManualTransform_;
 
     int lastShapeID_;
-    QTimer* checkPointTimer;
+    QTimer* checkPointTimer_;
 };
 
 }

--- a/src/VAC/View.cpp
+++ b/src/VAC/View.cpp
@@ -1379,6 +1379,7 @@ void View::adjustCellsColors()
 
 void View::drawShape(double x, double y, ShapeType shapeType, int countAngles, double initialRotation, bool drawingCircle)
 {
+    auto isSuccess = false;
     const auto currentMousePos = QPoint(mouse_Event_X_, mouse_Event_Y_);
 
     const auto pos = global()->getSnappedPosition(x, y);
@@ -1433,7 +1434,7 @@ void View::drawShape(double x, double y, ShapeType shapeType, int countAngles, d
         }
     };
 
-    auto processDrawShape = [this, &verticesPoints, &w, shapeType, &drawingCircle, &clearLastCells](bool isClosedShape = true)
+    auto processDrawShape = [this, &verticesPoints, &w, shapeType, &drawingCircle, &clearLastCells, &isSuccess](bool isClosedShape = true)
     {
         const auto verticesCount = verticesPoints.count();
 
@@ -1478,6 +1479,8 @@ void View::drawShape(double x, double y, ShapeType shapeType, int countAngles, d
             drawingCircle ? faceCell->setShapeType(ShapeType::CIRCLE) : faceCell->setShapeType(shapeType);
             lastDrawnCells_ << faceCell->toFaceCell();
         }
+
+        isSuccess = true;
     };
 
     switch (shapeType) {
@@ -1556,9 +1559,12 @@ void View::drawShape(double x, double y, ShapeType shapeType, int countAngles, d
         break;
     }
 
-    // Update the selection geometry for display the correct selection size when drawing
-    global()->updateSelectedGeometry(leftX, topY, shapeWidth, shapeHeight, true);
     lastMousePos_ = currentMousePos;
+
+    if (isSuccess) {
+        // Update the selection geometry for display the correct selection size when drawing
+        global()->updateSelectedGeometry(leftX, topY, shapeWidth, shapeHeight, true);
+    }
 }
 
 void View::updateView()

--- a/src/VAC/View.cpp
+++ b/src/VAC/View.cpp
@@ -84,9 +84,12 @@ View::View(VPaint::Scene * scene, QWidget * parent) :
     scene_(scene),
     pickingImg_(0),
     pickingIsEnabled_(true),
+    isMouseInSurface_(true),
     currentAction_(0),
     shapeStartX_(0),
     shapeStartY_(0),
+    lastDragX_(0.0),
+    lastDragY_(0.0),
     vac_(0)
 {
     // View settings widget
@@ -153,6 +156,30 @@ void View::resizeGL(int width, int height)
 void View::keyPressEvent(QKeyEvent *event)
 {
     event->ignore();
+
+    const auto moveDeltaX = global()->isGridSnapping() ?
+                                global()->gridSizeMM() :
+                                global()->arrowKeysMoveDelta().x();
+    const auto moveDeltaY = global()->isGridSnapping() ?
+                                global()->gridSizeMM() :
+                                global()->arrowKeysMoveDelta().y();
+
+    switch(event->key()){
+    case Qt::Key_Up:
+        moveSelected(0, -moveDeltaY);
+        break;
+    case Qt::Key_Down:
+        moveSelected(0, moveDeltaY);
+        break;
+    case Qt::Key_Right:
+        moveSelected(moveDeltaX, 0);
+        break;
+    case Qt::Key_Left:
+        moveSelected(-moveDeltaX, 0);
+        break;
+    default:
+        break;
+    }
 }
 
 
@@ -542,6 +569,9 @@ void View::MoveEvent(double x, double y)
     bool mustRedraw = false;
     global()->setSceneCursorPos(Eigen::Vector2d(x,y));
 
+    isMouseInSurface_ = global()->isPointInSurface(x, y);
+    update();
+
     // Update highlighted object
     bool hoveredObjectChanged = updateHoveredObject(mouse_Event_X_, mouse_Event_Y_);
     if(hoveredObjectChanged)
@@ -613,6 +643,9 @@ void View::PMRPressEvent(int action, double x, double y)
     // for mouse PMR actions
     global()->setSceneCursorPos(Eigen::Vector2d(x,y));
 
+    if (!isMouseInSurface_)
+        return;
+
     if(action==SKETCH_ACTION)
     {
         // here, possibly,  the scene  has several layers  that it
@@ -641,6 +674,8 @@ void View::PMRPressEvent(int action, double x, double y)
     }
     else if(action==DRAG_AND_DROP_ACTION)
     {
+        lastDragX_ = x;
+        lastDragY_ = y;
         vac_->prepareDragAndDrop(mouse_PressEvent_XScene_, mouse_PressEvent_YScene_, interactiveTime());
     }
     else if(action==TRANSFORM_SELECTION_ACTION)
@@ -755,7 +790,12 @@ void View::PMRMoveEvent(int action, double x, double y)
 
     if(action==DRAG_AND_DROP_ACTION)
     {
-        vac_->performDragAndDrop(x, y);
+        // Check if a new position of the shape will be inside the surfaces area
+        if (global()->isShapeInSurface(vac_->draggedVertices(), vac_->draggedEdges(), QPointF(x - lastDragX_, y - lastDragY_))) {
+            vac_->performDragAndDrop(x, y);
+            lastDragX_ = x;
+            lastDragY_ = y;
+        }
     }
     else if(action==TRANSFORM_SELECTION_ACTION)
     {
@@ -1121,14 +1161,23 @@ void View::drawCurve(double x, double y, ShapeDrawPhase drawPhase)
     switch (drawPhase) {
     case ShapeDrawPhase::DRAW_START:
     {
-        lastMousePos_ = QPoint(mouse_Event_X_, mouse_Event_Y_);
-        vac_->beginSketchEdge(xScene, yScene, w, interactiveTime());
-        emit allViewsNeedToUpdate();
+        if (isMouseInSurface_) {
+            lastMousePos_ = QPoint(mouse_Event_X_, mouse_Event_Y_);
+            vac_->beginSketchEdge(xScene, yScene, w, interactiveTime());
+            emit allViewsNeedToUpdate();
+        }
         break;
     }
     case ShapeDrawPhase::DRAW_PROCESS:
     {
-        vac_->continueSketchEdge(xScene, yScene, w);
+        if (global()->isPointInSurface(xScene, yScene)) {
+            vac_->continueSketchEdge(xScene, yScene, w);
+        } else {
+            // Stop drawing a curve if mouse out of surface, because the curve will
+            // be able to be visible outside the surface area, if continue moving the pressed
+            // mouse outside the surface and return back to the surface area.
+            forcedMouseRelease();
+        }
         break;
     }
     case ShapeDrawPhase::DRAW_END:
@@ -1334,19 +1383,20 @@ void View::drawShape(double x, double y, ShapeType shapeType, int countAngles, d
 {
     const auto currentMousePos = QPoint(mouse_Event_X_, mouse_Event_Y_);
 
-    if((currentMousePos - lastMousePos_).manhattanLength() < 3)
+    const auto pos = global()->getSnappedPosition(x, y);
+    const auto xScene = pos.x();
+    const auto yScene = pos.y();
+
+    if((currentMousePos - lastMousePos_).manhattanLength() < 3 || !global()->isPointInSurface(xScene, yScene))
         return;
 
+    using CellSet = VectorAnimationComplex::CellSet;
     using Vertex = VectorAnimationComplex::KeyVertex;
     using Edge = VectorAnimationComplex::KeyEdge;
     using EggeSet = VectorAnimationComplex::KeyEdgeSet;
     using Cycle = VectorAnimationComplex::Cycle;
 
     QVector<QPointF> verticesPoints(countAngles);
-
-    const auto pos = global()->getSnappedPosition(x, y);
-    const auto xScene = pos.x();
-    const auto yScene = pos.y();
 
     auto w = global()->settings().edgeWidth();
     if(mouse_isTablet_ &&  global()->useTabletPressure())
@@ -1376,15 +1426,24 @@ void View::drawShape(double x, double y, ShapeType shapeType, int countAngles, d
         }
     }
 
-    if (!lastDrawnCells_.isEmpty())
+    auto clearLastCells = [this]()
     {
-        vac_->deleteCells(lastDrawnCells_);
-        lastDrawnCells_.clear();
-    }
+        if (!lastDrawnCells_.isEmpty())
+        {
+            vac_->deleteCells(lastDrawnCells_);
+            lastDrawnCells_.clear();
+        }
+    };
 
-    auto processDrawShape = [this, &verticesPoints, &w, shapeType, &drawingCircle](bool isClosedShape = true)
+    auto processDrawShape = [this, &verticesPoints, &w, shapeType, &drawingCircle, &clearLastCells](bool isClosedShape = true)
     {
         const auto verticesCount = verticesPoints.count();
+
+        // Check if a new shape is inside the surfaces area
+        if (!global()->isShapeInSurface(verticesPoints))
+            return;
+
+        clearLastCells();
 
         //Draw Vertices
         QVector<Vertex*> vertices;
@@ -1433,6 +1492,7 @@ void View::drawShape(double x, double y, ShapeType shapeType, int countAngles, d
     }
     case ShapeType::CIRCLE:
     {
+        clearLastCells();
         const auto rx = shapeWidth / 2;
         const auto ry = shapeHeight / 2;
         const auto xCenter = leftX + rx;
@@ -1510,25 +1570,54 @@ void View::updateView()
     emit allViewsNeedToUpdate();
 }
 
+// Move the selection on delta in millimeters
+void View::moveSelected(const double dx_mm, const double dy_mm)
+{
+    if (vac_->hasSelectedCells()) {
+        const auto delta = QPointF(global()->surfaceScaleFactor() * dx_mm, global()->surfaceScaleFactor() * dy_mm);
+
+        vac_->setHoveredCell(vac_->selectedCells().toList().at(0));
+        auto bb = vac_->selectedOutlineBoundingBox();
+        vac_->prepareDragAndDrop(bb.xMin(), bb.yMin(), interactiveTime());
+
+        // Check if a new position of the shape will be inside the surfaces area
+        if (global()->isShapeInSurface(vac_->draggedVertices(), vac_->draggedEdges(), delta)) {
+            vac_->performDragAndDrop(bb.xMin() + delta.x(), bb.yMin() + delta.y());
+            vac_->completeDragAndDrop();
+            vac_->setNoHoveredAllCells();
+            updateView();
+        }
+    }
+}
+
+void View::forcedMouseRelease()
+{
+    QMouseEvent event(QEvent::MouseButtonRelease, lastMousePos_, Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+    qApp->sendEvent(this, &event);
+}
+
 void View::drawScene()
 {
     if(!mouse_HideCursor_)
     {
-        setCursor(Qt::ArrowCursor);
         switch(global()->toolMode())
         {
         case Global::SELECT:
             setCursor(Qt::ArrowCursor);
             break;
         case Global::SKETCH:
-        case Global::DRAW_LINE:
-            setCursor(Qt::CrossCursor);
-            break;
         case Global::PAINT:
-            setCursor(Qt::CrossCursor);
-            break;
         case Global::SCULPT:
-            setCursor(Qt::CrossCursor);
+        case Global::DRAW_LINE:
+        case Global::DRAW_RECTANGLE:
+        case Global::DRAW_CIRCLE:
+        case Global::DRAW_TRIANGLE:
+        case Global::DRAW_RHOMBUS:
+        case Global::DRAW_PENTAGON:
+        case Global::DRAW_HEXAGON:
+        case Global::DRAW_HEPTAGON:
+        case Global::DRAW_OCTAGON:
+            setCursor(isMouseInSurface_ ? Qt::CrossCursor : Qt::ArrowCursor);
             break;
         default:
             setCursor(Qt::CrossCursor);

--- a/src/VAC/View.cpp
+++ b/src/VAC/View.cpp
@@ -1161,11 +1161,9 @@ void View::drawCurve(double x, double y, ShapeDrawPhase drawPhase)
     switch (drawPhase) {
     case ShapeDrawPhase::DRAW_START:
     {
-        if (isMouseInSurface_) {
-            lastMousePos_ = QPoint(mouse_Event_X_, mouse_Event_Y_);
-            vac_->beginSketchEdge(xScene, yScene, w, interactiveTime());
-            emit allViewsNeedToUpdate();
-        }
+        lastMousePos_ = QPoint(mouse_Event_X_, mouse_Event_Y_);
+        vac_->beginSketchEdge(xScene, yScene, w, interactiveTime());
+        emit allViewsNeedToUpdate();
         break;
     }
     case ShapeDrawPhase::DRAW_PROCESS:
@@ -1387,7 +1385,7 @@ void View::drawShape(double x, double y, ShapeType shapeType, int countAngles, d
     const auto xScene = pos.x();
     const auto yScene = pos.y();
 
-    if((currentMousePos - lastMousePos_).manhattanLength() < 3 || !global()->isPointInSurface(xScene, yScene))
+    if((currentMousePos - lastMousePos_).manhattanLength() < 3)
         return;
 
     using CellSet = VectorAnimationComplex::CellSet;

--- a/src/VAC/View.h
+++ b/src/VAC/View.h
@@ -43,7 +43,6 @@ namespace VectorAnimationComplex
 class VAC;
 class KeyVertex;
 class KeyEdge;
-//class CellSet;
 }
 class Time;
 class Background;
@@ -189,6 +188,7 @@ private:
     uchar *pickingImg_;
     Picking::Object hoveredObject_;
     bool pickingIsEnabled_;
+    bool isMouseInSurface_;
 
     // PMR mouse event temp variables
     int currentAction_;
@@ -201,6 +201,9 @@ private:
 
     double shapeStartX_;
     double shapeStartY_;
+
+    double lastDragX_;
+    double lastDragY_;
 
     VectorAnimationComplex::CellSet lastDrawnCells_;
 
@@ -235,6 +238,9 @@ private:
     void drawPolygon(double x, double y, int countAngles, double rotation, ShapeDrawPhase drawPhase);
     void drawShape(double x, double y, ShapeType shapeType, int countAngles = 1, double initialRotation = 0, bool drawingCircle = false);
     void updateView();
+
+    void moveSelected(const double dx_mm, const double dy_mm);
+    void forcedMouseRelease();
 };
 
 #endif


### PR DESCRIPTION
Implemented restricting for draw/move/transform/rotate outside the surface area, added moving the selection by arrow keys