### PR TITLE
[BIOX-2813] DnP hapes are missing on surface

### DIFF
--- a/src/VAC/Scene.cpp
+++ b/src/VAC/Scene.cpp
@@ -889,6 +889,7 @@ void Scene::setActiveLayer(int i)
         emitChanged();
         emit needUpdatePicking();
         emit layerAttributesChanged();
+        emitCheckpoint();
     }
 }
 
@@ -920,6 +921,7 @@ Layer * Scene::createLayer()
 }
 void Scene::addLayer(Layer * layer )
 {
+    deselectAll();
     addLayer_(layer, true);
 
     // Move above active layer, or keep last if no active layer
@@ -941,8 +943,7 @@ void Scene::addLayer(Layer * layer )
     emitChanged();
     emit needUpdatePicking();
     emit layerAttributesChanged();
-
-    if (activeLayerIndex_ > 0) {
+    if (layers_.size() > 1) {
         emitCheckpoint();
     }
 }
@@ -1028,7 +1029,7 @@ void Scene::destroyLayer(const int index)
             activeLayerIndex_ = 0;
             activeLayer()->background()->setOpacity(1.0);
         }
-        else
+        else if (index <= activeLayerIndex_)
         {
             // had layer below
             --activeLayerIndex_;
@@ -1039,6 +1040,7 @@ void Scene::destroyLayer(const int index)
         emitChanged();
         emit needUpdatePicking();
         emit layerAttributesChanged();
+        emitCheckpoint();
     }
 }
 

--- a/src/VAC/Scene.cpp
+++ b/src/VAC/Scene.cpp
@@ -941,6 +941,10 @@ void Scene::addLayer(Layer * layer )
     emitChanged();
     emit needUpdatePicking();
     emit layerAttributesChanged();
+
+    if (activeLayerIndex_ > 0) {
+        emitCheckpoint();
+    }
 }
 
 Layer * Scene::createLayer(const QString & name)
@@ -999,13 +1003,17 @@ void Scene::moveActiveLayerDown()
 
 void Scene::destroyActiveLayer()
 {
-    int i = activeLayerIndex_;
-    if(0 <= i && i < numLayers())
+    destroyLayer(activeLayerIndex_);
+}
+
+void Scene::destroyLayer(const int index)
+{
+    if (0 <= index && index < numLayers())
     {
         deselectAll();
 
-        Layer * toBeDestroyedLayer = layers_[i];
-        layers_.removeAt(i);
+        Layer* toBeDestroyedLayer = layers_[index];
+        layers_.removeAt(index);
 
         // Set as active the layer below, unless it was the bottom-most layer
         // or the only layer in the scene.

--- a/src/VAC/Scene.h
+++ b/src/VAC/Scene.h
@@ -125,6 +125,7 @@ public:
 
     // destroy the given layer
     void destroyActiveLayer();
+    void destroyLayer(const int index);
     
     // GUI
     void populateToolBar(QToolBar * toolBar);

--- a/src/VAC/VectorAnimationComplex/VAC.cpp
+++ b/src/VAC/VectorAnimationComplex/VAC.cpp
@@ -1355,16 +1355,16 @@ void VAC::smartDelete_(const CellSet & cellsToDelete)
 
 QList<ShapeType> VAC::getAllShapesType()
 {
-    QList<ShapeType> types;
-    KeyFaceSet keyFaces = faces();
-    for (auto face : keyFaces)
+    QMap<int, ShapeType> types;
+    const auto keyVertices = instantVertices();
+    for (const auto keyVertex : keyVertices)
     {
-        if (!face->isIgnored())
+        if (!keyVertex->isIgnored())
         {
-            types.append(face->shapeType());
+            types.insert(keyVertex->shapeID(), keyVertex->shapeType());
         }
     }
-    return types;
+    return types.values();
 }
 
 QList<QColor> VAC::selectedShapesColor()
@@ -1399,22 +1399,27 @@ QList<QColor> VAC::selectedShapesColor()
 
 QList<ShapeType> VAC::getSelectedShapeType()
 {
-    QList<ShapeType> types;
-    KeyFaceSet keyVertices = selectedCells_;
-    for( auto vertex : keyVertices)
+    QMap<int, ShapeType> types;
+    const KeyVertexSet keyVertices = selectedCells_;
+    for (const auto keyVertex : keyVertices)
     {
-        types.append(vertex->shapeType());
+        if (!keyVertex->isIgnored())
+        {
+            types.insert(keyVertex->shapeID(), keyVertex->shapeType());
+        }
     }
-    return types;
+    return types.values();
 }
 
 ShapeType VAC::shapeType(const CellSet & cells)
 {
-    KeyFaceSet keyVertices = cells;
-    for( auto vertex : keyVertices)
+    const KeyVertexSet keyVertices = cells;
+    for(const auto keyVertex : keyVertices)
     {
-        ShapeType type =  vertex->shapeType();
-        return type;
+        if (!keyVertex->isIgnored()) {
+            ShapeType type = keyVertex->shapeType();
+            return type;
+        }
     }
     return ShapeType::NONE;
 }

--- a/src/VAC/View.cpp
+++ b/src/VAC/View.cpp
@@ -77,6 +77,8 @@ const constexpr auto POLYGON_ARROUND_VERTICES_TO = 9;
 const constexpr auto POLYGON_ARROUND_ALPHA = 0;
 const constexpr auto POLYGON_ARROUND_LINE_SIZE = 0.5;
 const constexpr auto DRAW_CIRCLES_AS_CURVES = false;
+// Used to restrict the ability to draw very small shapes
+const constexpr auto MIN_MOUSE_MOVE_TO_DRAW = 5;
 }
 
 View::View(VPaint::Scene * scene, QWidget * parent) :
@@ -1171,7 +1173,7 @@ void View::drawCurve(double x, double y, ShapeDrawPhase drawPhase)
     case ShapeDrawPhase::DRAW_PROCESS:
     {
         const auto currentMousePos = QPoint(mouse_Event_X_, mouse_Event_Y_);
-        if((currentMousePos - lastMousePos_).manhattanLength() < 5)
+        if((currentMousePos - lastMousePos_).manhattanLength() < MIN_MOUSE_MOVE_TO_DRAW)
             return;
 
         if (global()->isPointInSurface(xScene, yScene)) {
@@ -1395,7 +1397,7 @@ void View::drawShape(double x, double y, ShapeType shapeType, int countAngles, d
     const auto xScene = pos.x();
     const auto yScene = pos.y();
 
-    if((currentMousePos - lastMousePos_).manhattanLength() < 3)
+    if((currentMousePos - lastMousePos_).manhattanLength() < MIN_MOUSE_MOVE_TO_DRAW)
         return;
 
     using CellSet = VectorAnimationComplex::CellSet;

--- a/src/VAC/View.h
+++ b/src/VAC/View.h
@@ -205,6 +205,8 @@ private:
     double lastDragX_;
     double lastDragY_;
 
+    int startDrawVertexCount;
+
     VectorAnimationComplex::CellSet lastDrawnCells_;
 
     // Dirty implementation:


### PR DESCRIPTION
- Fixed BIOX-2813: added restriction to draw empty curves
- Fixed BIOX-2858: using vertices instead faces to determine the shape type
- Fixed behaviour of layers