### PR TITLE
[BIOX-2866] DnP When duplicate a layer a message should appear(hot fix for transforming)

### DIFF
--- a/src/VAC/View.cpp
+++ b/src/VAC/View.cpp
@@ -646,7 +646,7 @@ void View::PMRPressEvent(int action, double x, double y)
     // for mouse PMR actions
     global()->setSceneCursorPos(Eigen::Vector2d(x,y));
 
-    if (!isMouseInSurface_)
+    if (action != TRANSFORM_SELECTION_ACTION && !isMouseInSurface_)
         return;
 
     if(action==SKETCH_ACTION)


### PR DESCRIPTION
Hot fix for the transform/rotation. 
Allow begin transform in any case to prevent the unexpected behaviour when try to transform using the transform arrows/rectangles(by mouse) outside the surface (it doesn't affect the restriction for shapes).