### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/VAC/Global.h
+++ b/src/VAC/Global.h
@@ -168,7 +168,7 @@ public:
     void setPasteDelta(double delta);
 
     inline const QRectF& selectedGeometry() const { return selectedGeometry_; }
-    inline const double selectedRotation() const { return selectedRotation_; }
+    inline double selectedRotation() const { return selectedRotation_; }
     void updateSelectedGeometry(double x, double y, double w, double h, double rotation);
     void updateSelectedGeometry(double x, double y, double w, double h);
     void updateSelectedGeometry();
@@ -176,20 +176,20 @@ public:
     inline const QPointF& mousePastePosition() const { return mousePastePosition_; }
     void storeMousePastePos();
 
-    inline const VPaint::SurfaceType surfaceType() const { return surfaceType_; }
+    inline VPaint::SurfaceType surfaceType() const { return surfaceType_; }
     void setSurfaceType(VPaint::SurfaceType newSurfaceType);
 
-    inline const bool isShowGrid() const { return isShowGrid_; }
+    inline bool isShowGrid() const { return isShowGrid_; }
     void setShowGrid(bool showGrid);
 
-    inline const double gridSizeMM() const { return gridSizeMM_; }
-    inline const double gridSize() const { return gridSize_; }
+    inline double gridSizeMM() const { return gridSizeMM_; }
+    inline double gridSize() const { return gridSize_; }
     void setGridSize(double gridSizeMM);
 
-    inline const bool isGridSnapping() const { return isShowGrid_ && isGridSnapping_; }
+    inline bool isGridSnapping() const { return isShowGrid_ && isGridSnapping_; }
     void setGridSnapping(bool gridSnapping);
 
-    inline const double surfaceScaleFactor() const { return surfaceScaleFactor_; }
+    inline double surfaceScaleFactor() const { return surfaceScaleFactor_; }
     void setSurfaceScaleFactor(double scaleFactor);
 
     inline const QColor& surfaceBackGroundColor() const { return surfaceBackGroundColor_; }

--- a/src/VAC/SvgParser.cpp
+++ b/src/VAC/SvgParser.cpp
@@ -1587,7 +1587,7 @@ bool readRect(const QXmlStreamAttributes& attrs, VAC* vac, Time t,
     if(width == 0 || height == 0) return true;
 
     // The rx and ry attributes have a slightly more advanced default value, see W3 specifications for details
-    double rx, ry;
+    double rx = 0, ry = 0;
     bool rxOkay = false, ryOkay = false;
     if(attrs.hasAttribute("rx"))
     {

--- a/src/VAC/VectorAnimationComplex/Cell.h
+++ b/src/VAC/VectorAnimationComplex/Cell.h
@@ -339,13 +339,13 @@ public:
     ShapeType shapeType() const;
     void setShapeType(const ShapeType type);
 
-    inline const int shapeID() const { return shapeID_; }
+    inline int shapeID() const { return shapeID_; }
     void setShapeID(const int id);
 
-    inline const bool isIgnored() const { return isIgnored_; }
+    inline bool isIgnored() const { return isIgnored_; }
     void setIgnored(bool ignored);
 
-    inline const double rotation() const { return rotation_; }
+    inline double rotation() const { return rotation_; }
     void setRotation(const double newRotation);
 
 protected:

--- a/src/VAC/VectorAnimationComplex/SculptCurve.h
+++ b/src/VAC/VectorAnimationComplex/SculptCurve.h
@@ -1460,7 +1460,7 @@ public:
         std::vector< Curve<T>,Eigen::aligned_allocator<Curve<T> >  > res;
         // loop invariant: splitIndex-1 == res.size()
         //cout << "entering loop over split values" << endl;
-        while(splitIndex < nSplitValues)
+        while(splitIndex < int(nSplitValues))
         {
             //cout << "\n ## starting a new sub-curve ##" << endl;
 

--- a/src/VAC/VectorAnimationComplex/VAC.cpp
+++ b/src/VAC/VectorAnimationComplex/VAC.cpp
@@ -540,7 +540,7 @@ void VAC::draw(Time time, ViewSettings & viewSettings)
     ViewSettings::DisplayMode displayMode = viewSettings.displayMode();
 
     // Illustration mode
-    if( displayMode == ViewSettings::ILLUSTRATION)
+    if( displayMode == ViewSettings::ILLUSTRATION )
     {
         // Draw all cells
         for(auto c: zOrdering_)

--- a/src/VAC/VectorAnimationComplex/VAC.cpp
+++ b/src/VAC/VectorAnimationComplex/VAC.cpp
@@ -540,7 +540,7 @@ void VAC::draw(Time time, ViewSettings & viewSettings)
     ViewSettings::DisplayMode displayMode = viewSettings.displayMode();
 
     // Illustration mode
-    if( (displayMode == ViewSettings::ILLUSTRATION))
+    if( displayMode == ViewSettings::ILLUSTRATION)
     {
         // Draw all cells
         for(auto c: zOrdering_)
@@ -554,7 +554,7 @@ void VAC::draw(Time time, ViewSettings & viewSettings)
     }
 
     // Outline only mode
-    else if( (displayMode == ViewSettings::OUTLINE) )
+    else if( displayMode == ViewSettings::OUTLINE )
     {
         // Draw all cells
         for(auto c: zOrdering_)
@@ -566,7 +566,7 @@ void VAC::draw(Time time, ViewSettings & viewSettings)
     }
 
     // Illustration + Outline mode
-    else if( (displayMode == ViewSettings::ILLUSTRATION_OUTLINE) )
+    else if( displayMode == ViewSettings::ILLUSTRATION_OUTLINE )
     {
         // First pass
         for(auto c: zOrdering_)
@@ -773,7 +773,7 @@ void VAC::drawPick(Time time, ViewSettings & viewSettings)
 {
     ViewSettings::DisplayMode displayMode = viewSettings.displayMode();
 
-    if( (displayMode == ViewSettings::ILLUSTRATION) )
+    if( displayMode == ViewSettings::ILLUSTRATION )
     {
         // Draw all cells
         for(auto c: zOrdering_)
@@ -782,7 +782,7 @@ void VAC::drawPick(Time time, ViewSettings & viewSettings)
         }
     }
 
-    else if( (displayMode == ViewSettings::OUTLINE) )
+    else if( displayMode == ViewSettings::OUTLINE )
     {
         // Draw all cells
         for(auto c: zOrdering_)
@@ -791,7 +791,7 @@ void VAC::drawPick(Time time, ViewSettings & viewSettings)
         }
     }
 
-    else if( (displayMode == ViewSettings::ILLUSTRATION_OUTLINE) )
+    else if( displayMode == ViewSettings::ILLUSTRATION_OUTLINE )
     {
         // first pass: pick faces normally
         for(auto c: zOrdering_)
@@ -4356,7 +4356,7 @@ void VAC::insertSketchedEdgeInVAC(double tolerance, bool useFaceToConsiderForCut
     }
     else
     {
-        for(int i=0; i<nClusters; ++i)
+        for(auto i=0u; i<nClusters; ++i)
         {
             Cluster & cluster = clusters[i];
 

--- a/src/VAC/VectorAnimationComplex/VAC.h
+++ b/src/VAC/VectorAnimationComplex/VAC.h
@@ -104,7 +104,7 @@ public:
     const CellSet & selectedCells() const;
     const CellSet& hoveredCells() const;
     int numSelectedCells() const;
-    inline const bool hasSelectedCells() const { return selectedCells_.count() != 0; }
+    inline bool hasSelectedCells() const { return selectedCells_.count() != 0; }
 
     // Get hovered transform widget id
     int hoveredTransformWidgetId() const;


### PR DESCRIPTION
Returning const values is ignored by compiler, and makes no sense anyway. 
It also spews warnings and makes real issues harder to spot.